### PR TITLE
Add new Explicit dependency to catalystcenter_fabric_devices.fabric_devices

### DIFF
--- a/cc_fabric.tf
+++ b/cc_fabric.tf
@@ -316,7 +316,7 @@ resource "catalystcenter_fabric_devices" "fabric_devices" {
     prepend_autonomous_system_count = try(local.border_devices[device.name].prepend_autonomous_system_count, 0) == 0 ? null : try(local.border_devices[device.name].prepend_autonomous_system_count, local.defaults.catalyst_center.fabric.border_devices.prepend_autonomous_system_count, null)
   }]
 
-  depends_on = [catalystcenter_device_role.role, catalystcenter_provision_devices.provision_devices, catalystcenter_provision_device.provision_device]
+  depends_on = [catalystcenter_device_role.role, catalystcenter_provision_devices.provision_devices, catalystcenter_provision_device.provision_device, catalystcenter_wireless_device_provision.wireless_controller]
 }
 
 resource "catalystcenter_fabric_device" "border_device" {
@@ -709,4 +709,3 @@ resource "catalystcenter_extranet_policy" "extranet_policy" {
 
   depends_on = [catalystcenter_fabric_site.fabric_site, catalystcenter_fabric_l3_virtual_network.l3_vn, catalystcenter_virtual_network_to_fabric_site.l3_vn_to_fabric_site, catalystcenter_fabric_l3_virtual_network.global_l3_vn]
 }
-


### PR DESCRIPTION
Add catalystcenter_wireless_device_provision.wireless_controller Explicit dependency for catalystcenter_fabric_devices.fabric_devices

resource "catalystcenter_fabric_devices" "fabric_devices" {
!
!
  depends_on = [catalystcenter_device_role.role, catalystcenter_provision_devices.provision_devices, catalystcenter_provision_device.provision_device, catalystcenter_wireless_device_provision.wireless_controller]
}