### PR TITLE
Add lldp_level, dot11be_profile_id attributes and fix SNMPv2 description handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 **New Features:**
 - Add support for 6 additional site hierarchy area levels, extending total support to 10 area levels enabling deep organizational hierarchies up to `Global/area/area/area/area/area/area/area/area/area/area`
+- Add `lldp_level` attribute support for LLDP-based network discovery
+- Add `dot11be_profile_id` attribute support for wireless network profiles to enable Wi-Fi 7 (802.11be) profile assignment
 
 **Improvements:**
 - Add bulk site resource support via `use_bulk_api` flag for areas, buildings, and floors using new map-based provider resource (`catalystcenter_areas`, `catalystcenter_buildings`, `catalystcenter_floors`)
@@ -17,6 +19,7 @@
 - Fix `bulk_site_provisioning_validation` to only run when bulk provisioning is enabled
 - Fix fabric zones not being created in multi-state deployments due to incorrect site filtering
 - Fix L3 virtual networks not being attached to fabric zones in multi-state deployments
+- Fix SNMPv2 read/write credentials to use optional `description` field when provided, falling back to `name` if not specified
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 **New Features:**
 - Add support for 6 additional site hierarchy area levels, extending total support to 10 area levels enabling deep organizational hierarchies up to `Global/area/area/area/area/area/area/area/area/area/area`
 - Add `lldp_level` attribute support for LLDP-based network discovery
-- Add `dot11be_profile_id` attribute support for wireless network profiles to enable Wi-Fi 7 (802.11be) profile assignment
 
 **Improvements:**
 - Add bulk site resource support via `use_bulk_api` flag for areas, buildings, and floors using new map-based provider resource (`catalystcenter_areas`, `catalystcenter_buildings`, `catalystcenter_floors`)

--- a/cc_discovery.tf
+++ b/cc_discovery.tf
@@ -25,6 +25,7 @@ resource "catalystcenter_discovery" "discovery" {
   discovery_type            = try(each.value.type, local.defaults.catalyst_center.inventory.discovery.type, null)
   protocol_order            = try(each.value.protocol_order, local.defaults.catalyst_center.inventory.discovery.protocol_order, null)
   cdp_level                 = try(each.value.cdp_level, local.defaults.catalyst_center.inventory.discovery.cdp_level, null)
+  lldp_level                = try(each.value.lldp_level, local.defaults.catalyst_center.inventory.discovery.lldp_level, null)
   enable_password_list      = try(each.value.enable_password_list, local.defaults.catalyst_center.inventory.discovery.enable_password_list, null)
   global_credential_id_list = try([for cred in each.value.global_credential_list : local.all_credential_ids[cred]], null)
   http_read_credential      = try(each.value.http_read_credential, local.defaults.catalyst_center.inventory.discovery.http_read_credential, null)

--- a/cc_network_settings.tf
+++ b/cc_network_settings.tf
@@ -66,14 +66,14 @@ resource "catalystcenter_credentials_cli" "cli_credentials" {
 resource "catalystcenter_credentials_snmpv2_read" "snmpv2_read_credentials" {
   for_each = { for cred in try(local.catalyst_center.network_settings.device_credentials.snmpv2_read_credentials, []) : cred.name => cred if var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0) }
 
-  description    = each.key
+  description    = try(each.value.description, each.key)
   read_community = try(each.value.read_community, local.defaults.catalyst_center.network_settings.device_credentials.snmpv2_read_credentials.read_community, null)
 }
 
 resource "catalystcenter_credentials_snmpv2_write" "snmpv2_write_credentials" {
   for_each = { for cred in try(local.catalyst_center.network_settings.device_credentials.snmpv2_write_credentials, []) : cred.name => cred if var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0) }
 
-  description     = each.key
+  description     = try(each.value.description, each.key)
   write_community = try(each.value.write_community, local.defaults.catalyst_center.network_settings.device_credentials.snmpv2_write_credentials.write_community, null)
 }
 

--- a/cc_wireless.tf
+++ b/cc_wireless.tf
@@ -228,7 +228,6 @@ resource "catalystcenter_wireless_profile" "wireless_profile" {
     local_to_vlan       = try(ssid.enable_flex_connect, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.enable_flex_connect, false) == true ? try(ssid.local_to_vlan, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.local_to_vlan, null) : null
     interface_name      = try(ssid.enable_fabric, false) == false ? try(ssid.interface_name, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.interface_name, null) : null
     wlan_profile_name   = try(ssid.wlan_profile_name, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.wlan_profile_name, null)
-    dot11be_profile_id  = try(ssid.dot11be_profile_id, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.dot11be_profile_id, null)
   }], null)
   additional_interfaces = try(each.value.additional_interfaces, null)
   ap_zones = try([for ap_zone in each.value.ap_zones : {

--- a/cc_wireless.tf
+++ b/cc_wireless.tf
@@ -228,6 +228,7 @@ resource "catalystcenter_wireless_profile" "wireless_profile" {
     local_to_vlan       = try(ssid.enable_flex_connect, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.enable_flex_connect, false) == true ? try(ssid.local_to_vlan, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.local_to_vlan, null) : null
     interface_name      = try(ssid.enable_fabric, false) == false ? try(ssid.interface_name, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.interface_name, null) : null
     wlan_profile_name   = try(ssid.wlan_profile_name, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.wlan_profile_name, null)
+    dot11be_profile_id  = try(ssid.dot11be_profile_id, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.dot11be_profile_id, null)
   }], null)
   additional_interfaces = try(each.value.additional_interfaces, null)
   ap_zones = try([for ap_zone in each.value.ap_zones : {


### PR DESCRIPTION
feat: add lldp_level and dot11be_profile_id support, fix SNMPv2 description

- Add lldp_level attribute for LLDP-based discovery
- Add dot11be_profile_id for Wi-Fi 7 wireless profiles  
- Fix SNMPv2 credentials to use description field when provided