### PR TITLE
feat(wireless): add 802.11be profile support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **New Features:**
 - Add support for 6 additional site hierarchy area levels, extending total support to 10 area levels enabling deep organizational hierarchies up to `Global/area/area/area/area/area/area/area/area/area/area`
 - Add `lldp_level` attribute support for LLDP-based network discovery
+- Add 802.11be (WiFi 7) profile support with `catalystcenter_dot11be_profile` resource for creating and managing dot11be profiles with OFDMA and MU-MIMO settings
+- Add `dot11be_profile_name` attribute to wireless network profile `ssid_details` for associating 802.11be profiles with SSIDs (requires IOS 17.15+)
 
 **Improvements:**
 - Enhance device provisioning grouping logic to support `bulk_site_provisioning` and `managed_sites` with proper hierarchical site matching
@@ -11,6 +13,7 @@
 - Add `device_discovery_validation` check block to validate device presence in Catalyst Center inventory during plan phase, and improve error handling for devices not found in inventory by filtering them out from resource operations instead of failing with coalesce errors
 - Add validation for `managed_sites` variable to ensure all sites specified exist in YAML configuration with precondition check
 - Add validation for `bulk_site_provisioning` variable to verify site hierarchy format and existence in YAML configuration
+- Add universal 802.11be profile resolution supporting both Terraform-managed profiles and pre-existing profiles created outside of Terraform
 
 **Bug Fixes:**
 - Fix device provisioning grouping under managed sites to prevent empty or incorrect site mappings caused by full path matching instead of parent site hierarchy
@@ -20,7 +23,6 @@
 - Fix `bulk_site_provisioning_validation` to only run when bulk provisioning is enabled
 - Fix fabric zones not being created in multi-state deployments due to incorrect site filtering
 - Fix L3 virtual networks not being attached to fabric zones in multi-state deployments
-- Fix SNMPv2 read/write credentials to use optional `description` field when provided, falling back to `name` if not specified
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ module "catalystcenter" {
 | [catalystcenter_discovery.discovery](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/discovery) | resource |
 | [catalystcenter_dns_settings.dns_settings](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/dns_settings) | resource |
 | [catalystcenter_dns_settings.global_dns_settings](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/dns_settings) | resource |
+| [catalystcenter_dot11be_profile.dot11be_profile](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/dot11be_profile) | resource |
 | [catalystcenter_extranet_policy.extranet_policy](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/extranet_policy) | resource |
 | [catalystcenter_fabric_device.border_device](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/fabric_device) | resource |
 | [catalystcenter_fabric_device.edge_device](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/fabric_device) | resource |
@@ -178,6 +179,7 @@ module "catalystcenter" {
 | [time_sleep.template_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [catalystcenter_anycast_gateways.created_gateways](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/anycast_gateways) | data source |
 | [catalystcenter_assign_credentials.global_assign_credentials](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/assign_credentials) | data source |
+| [catalystcenter_dot11be_profile.dot11be_profile](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/dot11be_profile) | data source |
 | [catalystcenter_fabric_l3_virtual_network.l3_vn](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/fabric_l3_virtual_network) | data source |
 | [catalystcenter_fabric_sites.fabric_sites](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/fabric_sites) | data source |
 | [catalystcenter_ip_pools.all_ip_pools](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/ip_pools) | data source |

--- a/cc_wireless.tf
+++ b/cc_wireless.tf
@@ -29,14 +29,6 @@ locals {
     for name in local.dot11be_profile_names_referenced : name
     if !contains(local.dot11be_profile_names_managed, name)
   ]
-
-  # Build combined name → ID map from both managed resources and data sources
-  dot11be_profile_map = merge(
-    # From managed resources (created by Terraform)
-    { for name, profile in catalystcenter_dot11be_profile.dot11be_profile : name => profile.id },
-    # From data sources (existing profiles)
-    { for name, profile in data.catalystcenter_dot11be_profile.dot11be_profile : name => profile.id }
-  )
 }
 
 # Create 802.11be profiles from YAML configuration
@@ -273,7 +265,7 @@ resource "catalystcenter_wireless_profile" "wireless_profile" {
     interface_name      = try(ssid.enable_fabric, false) == false ? try(ssid.interface_name, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.interface_name, null) : null
     wlan_profile_name   = try(ssid.wlan_profile_name, local.defaults.catalyst_center.network_profiles.wireless.ssid_details.wlan_profile_name, null)
     # Direct reference to ensure proper dependency tracking - try managed resource first, then data source
-    dot11be_profile_id  = try(ssid.dot11be_profile_name, null) != null ? try(
+    dot11be_profile_id = try(ssid.dot11be_profile_name, null) != null ? try(
       catalystcenter_dot11be_profile.dot11be_profile[ssid.dot11be_profile_name].id,
       data.catalystcenter_dot11be_profile.dot11be_profile[ssid.dot11be_profile_name].id,
       null


### PR DESCRIPTION
- Add catalystcenter_dot11be_profile resource for WiFi 7 profiles
- Add dot11be_profile_name to wireless network profile ssid_details
- Support both TF-managed and existing profiles (universal resolution)