### PR TITLE
Device tag ignore and L2VN anycast without vlan id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Fix wireless SSID `auth_type` value mapping to correctly transform `OPEN_SECURED` to `OPEN-SECURED` for API compatibility
 - Add dependency on provision WLC to wait for managed AP locations in bulk site provision scenerios
 
+**Improvements:**
+- Ignore device tag check for devices in INIT state
+- Allow L2VN anycast gateway creation without specifying vlan id
+
 ## 0.4.0
 
 **New Features:**

--- a/cc_fabric.tf
+++ b/cc_fabric.tf
@@ -640,7 +640,7 @@ locals {
 
 locals {
   l2_handoff_vlan_id_map_no_anycast = {
-    for item in local.l2_virtual_networks : "${item.vlan_name}#_#${item.fabric_site_name}" => item.vlan_id if try(item.vlan_name, null) != null
+    for item in local.l2_virtual_networks : "${item.vlan_name}#_#${item.fabric_site_name}" => try(item.vlan_id, null) if try(item.vlan_name, null) != null
   }
 }
 

--- a/cc_templates.tf
+++ b/cc_templates.tf
@@ -73,7 +73,7 @@ locals {
         "device_ip" : device.device_ip
         "fqdn_name" : device.fqdn_name
       }
-    ] if try(device.tags, null) != null
+    ] if try(device.tags, null) != null && (strcontains(device.state, "PROVISION") || device.state == "ASSIGN")
   ])
 
   devices_to_tag = [


### PR DESCRIPTION
 Ignore device tag check for devices in INIT state
 Allow L2VN anycast gateway creation without specifying vlan id