### PR TITLE
support same template name in multiple template project

### DIFF
--- a/cc_device_provision.tf
+++ b/cc_device_provision.tf
@@ -17,7 +17,7 @@ locals {
       {
         dayn_templates_map = merge(
           {
-            for template in try(device.dayn_templates.regular, []) : template.name => {
+            for template in try(device.dayn_templates.regular, []) : try("${template.project_name}#${template.name}", template.name) => {
               name                = try(template.name, null)
               variables           = try(template.variables, [])
               copying_config      = try(template.copying_config, null)
@@ -25,7 +25,7 @@ locals {
             }
           },
           {
-            for template in try(device.dayn_templates.composite, []) : template.name => {
+            for template in try(device.dayn_templates.composite, []) : try("${template.project_name}#${template.name}", template.name) => {
               name                = try(template.name, null)
               variables           = try(template.variables, [])
               copying_config      = try(template.copying_config, null)

--- a/cc_network_profiles.tf
+++ b/cc_network_profiles.tf
@@ -5,7 +5,7 @@ locals {
         "type" : "cli.templates"
         "attributes" : [for template in try(profile.dayn_templates, []) :
           {
-            "template_id" : try(catalystcenter_template.regular_template["${template.project_name}#${template.name}"].id, catalystcenter_template.composite_template["${template.project_name}#${template.name}"].id, catalystcenter_template.regular_template[local.template_name_to_key[try(template.name, template)]].id, catalystcenter_template.composite_template[local.template_name_to_key[try(template.name, template)]].id, null)
+            "template_id" : try(catalystcenter_template.regular_template[template].id, catalystcenter_template.composite_template[template].id, catalystcenter_template.regular_template[local.template_name_to_key[template]].id, catalystcenter_template.composite_template[local.template_name_to_key[template]].id, null)
           }
         ]
         },
@@ -13,7 +13,7 @@ locals {
           "type" : "day0.templates"
           "attributes" : [for template in try(profile.onboarding_templates, []) :
             {
-              "template_id" : try(catalystcenter_template.regular_template["${template.project_name}#${template.name}"].id, catalystcenter_template.composite_template["${template.project_name}#${template.name}"].id, catalystcenter_template.regular_template[local.template_name_to_key[try(template.name, template)]].id, catalystcenter_template.composite_template[local.template_name_to_key[try(template.name, template)]].id, null)
+              "template_id" : try(catalystcenter_template.regular_template[template].id, catalystcenter_template.composite_template[template].id, catalystcenter_template.regular_template[local.template_name_to_key[template]].id, catalystcenter_template.composite_template[local.template_name_to_key[template]].id, null)
             }
           ]
       }]

--- a/cc_network_profiles.tf
+++ b/cc_network_profiles.tf
@@ -3,17 +3,17 @@ locals {
     for profile in try(local.catalyst_center.network_profiles.switching, {}) : profile.name => {
       "templates" : [{
         "type" : "cli.templates"
-        "attributes" : [for template_name in try(profile.dayn_templates, []) :
+        "attributes" : [for template in try(profile.dayn_templates, []) :
           {
-            "template_id" : try(catalystcenter_template.regular_template[template_name].id, catalystcenter_template.composite_template[template_name].id, null)
+            "template_id" : try(catalystcenter_template.regular_template["${template.project_name}#${template.name}"].id, catalystcenter_template.composite_template["${template.project_name}#${template.name}"].id, catalystcenter_template.regular_template[local.template_name_to_key[try(template.name, template)]].id, catalystcenter_template.composite_template[local.template_name_to_key[try(template.name, template)]].id, null)
           }
         ]
         },
         {
           "type" : "day0.templates"
-          "attributes" : [for template_name in try(profile.onboarding_templates, []) :
+          "attributes" : [for template in try(profile.onboarding_templates, []) :
             {
-              "template_id" : try(catalystcenter_template.regular_template[template_name].id, catalystcenter_template.composite_template[template_name].id, null)
+              "template_id" : try(catalystcenter_template.regular_template["${template.project_name}#${template.name}"].id, catalystcenter_template.composite_template["${template.project_name}#${template.name}"].id, catalystcenter_template.regular_template[local.template_name_to_key[try(template.name, template)]].id, catalystcenter_template.composite_template[local.template_name_to_key[try(template.name, template)]].id, null)
             }
           ]
       }]

--- a/cc_pnp.tf
+++ b/cc_pnp.tf
@@ -19,7 +19,7 @@ resource "catalystcenter_pnp_device_claim_site" "claim_device" {
   rf_profile        = try(each.value.rf_profile, local.defaults.catalyst_center.pnp.devices.rf_profile, null)
   image_id          = try(each.value.image_id, local.defaults.catalyst_center.pnp.devices.image_id, null)
   image_skip        = try(each.value.image_skip, local.defaults.catalyst_center.pnp.devices.image_skip, null)
-  config_id         = try(catalystcenter_template.regular_template[each.value.onboarding_template.name].id, data.catalystcenter_template.template[each.value.onboarding_template.name].id, null)
+  config_id         = try(catalystcenter_template.regular_template["${each.value.onboarding_template.project_name}#${each.value.onboarding_template.name}"].id, catalystcenter_template.regular_template[local.template_name_to_key[each.value.onboarding_template.name]].id, data.catalystcenter_template.template["${each.value.onboarding_template.project_name}#${each.value.onboarding_template.name}"].id, data.catalystcenter_template.template[local.resource_key_to_template_key[local.template_name_to_key[each.value.onboarding_template.name]]].id, null)
   config_parameters = try(each.value.onboarding_template.variables, local.defaults.catalyst_center.onboarding_templates.variables, null)
 
   depends_on = [catalystcenter_network_profile.switching_network_profile]

--- a/cc_pnp.tf
+++ b/cc_pnp.tf
@@ -19,7 +19,7 @@ resource "catalystcenter_pnp_device_claim_site" "claim_device" {
   rf_profile        = try(each.value.rf_profile, local.defaults.catalyst_center.pnp.devices.rf_profile, null)
   image_id          = try(each.value.image_id, local.defaults.catalyst_center.pnp.devices.image_id, null)
   image_skip        = try(each.value.image_skip, local.defaults.catalyst_center.pnp.devices.image_skip, null)
-  config_id         = try(catalystcenter_template.regular_template["${each.value.onboarding_template.project_name}#${each.value.onboarding_template.name}"].id, catalystcenter_template.regular_template[local.template_name_to_key[each.value.onboarding_template.name]].id, data.catalystcenter_template.template["${each.value.onboarding_template.project_name}#${each.value.onboarding_template.name}"].id, data.catalystcenter_template.template[local.resource_key_to_template_key[local.template_name_to_key[each.value.onboarding_template.name]]].id, null)
+  config_id         = try(catalystcenter_template.regular_template[each.value.onboarding_template.name].id, catalystcenter_template.regular_template[local.template_name_to_key[each.value.onboarding_template.name]].id, data.catalystcenter_template.template[each.value.onboarding_template.name].id, data.catalystcenter_template.template[local.resource_key_to_template_key[each.value.onboarding_template.name]].id, data.catalystcenter_template.template[local.resource_key_to_template_key[local.template_name_to_key[each.value.onboarding_template.name]]].id, null)
   config_parameters = try(each.value.onboarding_template.variables, local.defaults.catalyst_center.onboarding_templates.variables, null)
 
   depends_on = [catalystcenter_network_profile.switching_network_profile]

--- a/cc_templates.tf
+++ b/cc_templates.tf
@@ -10,14 +10,33 @@ locals {
     for file in local.yaml_templates_directories : split(".", split("/", file)[length(split("/", file)) - 1])[0] => replace(file(file), "\r\n", "\n")
   }
 
+  # Count how many times each template name appears across all projects.
+  # Used to determine if a bare name can serve as a unique resource key.
+  template_name_counts = {
+    for name, occurrences in {
+      for t in flatten([
+        for project in try(local.catalyst_center.templates.projects, []) : [
+          for template in concat(try(project.onboarding_templates, []), try(project.dayn_templates, [])) : {
+            name = template.name
+          }
+        ]
+      ]) : t.name => true...
+    } : name => length(occurrences)
+  }
+
   templates = flatten([
     for project in try(local.catalyst_center.templates.projects, []) : [
       for template in concat(try(project.onboarding_templates, []), try(project.dayn_templates, [])) : merge(template,
         {
-          project_name      = project.name
-          template_name     = template.name
-          redeploy_template = try(template.redeploy_template, local.defaults.catalyst_center.templates.redeploy_template, null)
-          template_type     = contains(try(project.onboarding_templates, []), template) ? "onboarding" : "dayn"
+          project_name  = project.name
+          template_name = template.name
+          template_key  = "${project.name}#${template.name}"
+          # resource_key: Use bare name for backward compatibility when template name is unique across projects.
+          # Only use composite key when the same template name exists in multiple projects.
+          resource_key       = local.template_name_counts[template.name] == 1 ? template.name : "${project.name}#${template.name}"
+          template_file_name = contains(keys(local.templates_content), "${project.name}#${template.name}") ? "${project.name}#${template.name}" : template.name
+          redeploy_template  = try(template.redeploy_template, local.defaults.catalyst_center.templates.redeploy_template, null)
+          template_type      = contains(try(project.onboarding_templates, []), template) ? "onboarding" : "dayn"
         }
       )
     ]
@@ -28,6 +47,7 @@ locals {
       for template in concat(try(project.onboarding_templates, []), try(project.dayn_templates, [])) : {
         project_name  = project.name
         template_name = template.name
+        template_key  = "${project.name}#${template.name}"
       }
     ]
   ])
@@ -36,52 +56,77 @@ locals {
     for project in try(local.catalyst_center.templates.projects, []) : [
       for tmpl in try(project.dayn_templates, []) : [
         {
-          "containing_templates" : tmpl.containing_templates
+          "containing_templates" : [for ct in tmpl.containing_templates : local.template_name_counts[ct] == 1 ? ct : "${project.name}#${ct}"]
           "template_name" : tmpl.name
+          "resource_key" : local.template_name_counts[tmpl.name] == 1 ? tmpl.name : "${project.name}#${tmpl.name}"
+          "template_key" : "${project.name}#${tmpl.name}"
         }
       ] if try(tmpl.composite, false) == true
     ]
   ])
 
   composite_templates_map = {
-    for tmpl in local.composite_templates_list : tmpl.template_name => tmpl.containing_templates
+    for tmpl in local.composite_templates_list : tmpl.resource_key => tmpl.containing_templates
   }
 
-  templates_map = { for template in local.templates : template.template_name => template }
+  templates_map = { for template in local.templates : template.resource_key => template }
+
+  template_name_to_key = {
+    for name, keys in {
+      for t in local.templates : t.template_name => t.resource_key...
+    } : name => keys[0] if length(keys) == 1
+  }
+
+  # Bridge from resource_key (bare name) to template_key (composite) for data source lookups
+  # in multi-state scenarios where resources are empty and only data sources (keyed by template_key) exist.
+  resource_key_to_template_key = {
+    for t in local.templates : t.resource_key => t.template_key
+    if t.resource_key != t.template_key
+  }
+
+  template_lookup = merge(
+    local.templates_map,
+    { for name, key in local.template_name_to_key : name => local.templates_map[key] }
+  )
+
+  composite_templates_lookup = merge(
+    local.composite_templates_map,
+    { for name, key in local.template_name_to_key : name => local.composite_templates_map[key] if contains(keys(local.composite_templates_map), key) }
+  )
 
   tag_templates = flatten([
     for template in try(local.templates, []) : [
       for tag in try(template.tags, []) : {
-        "tag_name" : tag,
-        "template_name" : template.template_name
+        "tag_name"     = tag,
+        "resource_key" = template.resource_key
       }
     ] if try(template.tags, null) != null
   ])
 
   templates_to_tag = [
     for tag_key in distinct([for t in local.tag_templates : t.tag_name]) : {
-      "tag_name" : tag_key
-      "template_names" : [for t in local.tag_templates : t.template_name if t.tag_name == tag_key]
+      "tag_name"      = tag_key
+      "resource_keys" = [for t in local.tag_templates : t.resource_key if t.tag_name == tag_key]
     }
   ]
 
   tag_devices = flatten([
     for device in try(local.catalyst_center.inventory.devices, []) : [
       for tag in try(device.tags, []) : {
-        "tag_name" : tag,
-        "device_name" : device.name
-        "device_ip" : device.device_ip
-        "fqdn_name" : device.fqdn_name
+        "tag_name"    = tag,
+        "device_name" = device.name
+        "device_ip"   = device.device_ip
+        "fqdn_name"   = device.fqdn_name
       }
     ] if try(device.tags, null) != null && (strcontains(device.state, "PROVISION") || device.state == "ASSIGN")
   ])
 
   devices_to_tag = [
     for tag_key in distinct([for t in local.tag_devices : t.tag_name]) : {
-      "tag_name" : tag_key
-      "device_names" : [for t in local.tag_devices : t.device_name if t.tag_name == tag_key]
-      "device_ips" : [for t in local.tag_devices : t.device_ip if t.tag_name == tag_key]
-      "fqdn_names" : [for t in local.tag_devices : t.fqdn_name if t.tag_name == tag_key]
+      "tag_name"     = tag_key
+      "device_names" = [for t in local.tag_devices : t.device_name if t.tag_name == tag_key]
+      "device_ips"   = [for t in local.tag_devices : t.device_ip if t.tag_name == tag_key]
+      "fqdn_names"   = [for t in local.tag_devices : t.fqdn_name if t.tag_name == tag_key]
     }
   ]
 
@@ -89,16 +134,17 @@ locals {
     for device in try(local.catalyst_center.inventory.devices, []) : [
       for template in concat(try(device.dayn_templates.regular, []), try(device.dayn_templates.composite, [])) : [
         {
-          "template" : try(template.name, null),
-          "name" : try(device.name, null),
-          "state" : try(device.state, null),
-          "site" : try(device.site, null),
-          "device_ip" : try(device.device_ip, null)
-          "device_name" : try(device.name, null)
-          "redeploy_template" : try(template.redeploy_template, device.dayn_templates.redeploy_template, local.templates_map[template.name].redeploy_template, null)
-          "fqdn_name" : try(device.fqdn_name, null)
-          "copying_config" : try(template.copying_config, local.defaults.catalyst_center.templates.copying_config, null)
-          "force_push_template" : try(template.force_push_template, local.defaults.catalyst_center.templates.force_push_template, null)
+          "template"            = try("${template.project_name}#${template.name}", template.name),
+          "template_name"       = try(template.name, null),
+          "name"                = try(device.name, null),
+          "state"               = try(device.state, null),
+          "site"                = try(device.site, null),
+          "device_ip"           = try(device.device_ip, null)
+          "device_name"         = try(device.name, null)
+          "redeploy_template"   = try(template.redeploy_template, device.dayn_templates.redeploy_template, local.template_lookup[try("${template.project_name}#${template.name}", template.name)].redeploy_template, null)
+          "fqdn_name"           = try(device.fqdn_name, null)
+          "copying_config"      = try(template.copying_config, local.defaults.catalyst_center.templates.copying_config, null)
+          "force_push_template" = try(template.force_push_template, local.defaults.catalyst_center.templates.force_push_template, null)
         }
       ]
     ]
@@ -132,14 +178,14 @@ data "catalystcenter_project" "project" {
 }
 
 data "catalystcenter_template" "template" {
-  for_each = var.manage_global_settings == false && length(var.managed_sites) != 0 ? { for template in try(local.project_templates, []) : template.template_name => template.project_name } : {}
+  for_each = var.manage_global_settings == false && length(var.managed_sites) != 0 ? { for template in try(local.project_templates, []) : template.template_key => template } : {}
 
-  name       = each.key
-  project_id = try(catalystcenter_project.project[each.key].id, data.catalystcenter_project.project[each.value].id, null)
+  name       = each.value.template_name
+  project_id = try(catalystcenter_project.project[each.value.template_name].id, data.catalystcenter_project.project[each.value.project_name].id, null)
 }
 
 data "catalystcenter_template_versions" "template_versions" {
-  for_each = var.manage_global_settings == false && length(var.managed_sites) != 0 ? { for template in try(local.project_templates, []) : template.template_name => template.project_name } : {}
+  for_each = var.manage_global_settings == false && length(var.managed_sites) != 0 ? { for template in try(local.project_templates, []) : template.template_key => template } : {}
 
   template_id = data.catalystcenter_template.template[each.key].id
 }
@@ -152,16 +198,16 @@ resource "catalystcenter_project" "project" {
 }
 
 resource "catalystcenter_template" "regular_template" {
-  for_each = { for template in try(concat(local.templates), []) : template.template_name => template if try(template.composite, false) == false && (var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0)) }
+  for_each = { for template in try(concat(local.templates), []) : template.resource_key => template if try(template.composite, false) == false && (var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0)) }
 
-  name             = each.key
+  name             = each.value.template_name
   project_id       = try(catalystcenter_project.project[each.value.project_name].id, data.catalystcenter_project.onboarding.id, null)
   description      = try(each.value.description, local.defaults.catalyst_center.templates.description, null)
   device_types     = try(each.value.device_types, local.defaults.catalyst_center.templates.device_types, null)
   language         = try(each.value.language, local.defaults.catalyst_center.templates.language, null)
   software_type    = try(each.value.software_type, local.defaults.catalyst_center.templates.software_type, null)
   software_version = try(each.value.software_version, local.catalyst_center.templates.software_version, null)
-  template_content = local.templates_content[each.key]
+  template_content = local.templates_content[each.value.template_file_name]
   composite        = try(each.value.composite, local.defaults.catalyst_center.templates.composite, null)
 
   template_params = [for param in try(each.value.variables, []) : {
@@ -189,9 +235,9 @@ resource "time_sleep" "template_wait" {
 }
 
 resource "catalystcenter_template" "composite_template" {
-  for_each = { for template in try(concat(local.templates), []) : template.template_name => template if try(template.composite, false) == true && (var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0)) }
+  for_each = { for template in try(concat(local.templates), []) : template.resource_key => template if try(template.composite, false) == true && (var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0)) }
 
-  name             = each.key
+  name             = each.value.template_name
   project_id       = try(catalystcenter_project.project[each.value.project_name].id, data.catalystcenter_project.onboarding.id, null)
   description      = try(each.value.description, local.defaults.catalyst_center.templates.description, null)
   device_types     = try(each.value.device_types, local.defaults.catalyst_center.templates.device_types, null)
@@ -200,11 +246,11 @@ resource "catalystcenter_template" "composite_template" {
   software_version = try(each.value.software_version, local.catalyst_center.templates.software_version, null)
   composite        = try(each.value.composite, local.defaults.catalyst_center.templates.composite, null)
 
-  containing_templates = [for containing_template in try(each.value.containing_templates, []) : {
-    name         = containing_template
-    id           = try(catalystcenter_template.regular_template[containing_template].id, null)
-    language     = try(catalystcenter_template.regular_template[containing_template].language, local.defaults.catalyst_center.templates.language, null)
-    project_name = try(each.value.project_name, containing_template.project_name, null)
+  containing_templates = [for containing_template_key in try(local.composite_templates_map[each.key], []) : {
+    name         = local.templates_map[containing_template_key].template_name
+    id           = try(catalystcenter_template.regular_template[containing_template_key].id, null)
+    language     = try(catalystcenter_template.regular_template[containing_template_key].language, local.defaults.catalyst_center.templates.language, null)
+    project_name = try(each.value.project_name, null)
     }
   ]
 
@@ -215,7 +261,7 @@ resource "catalystcenter_assign_templates_to_tag" "template_to_tag" {
   for_each = { for tag in try(local.templates_to_tag, []) : tag.tag_name => tag if var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0) }
 
   tag_id       = catalystcenter_tag.tag[each.key].id
-  template_ids = [for template in each.value.template_names : try(catalystcenter_template.regular_template[template].id, catalystcenter_template.composite_template[template].id, null)]
+  template_ids = [for resource_key in each.value.resource_keys : try(catalystcenter_template.regular_template[resource_key].id, catalystcenter_template.composite_template[resource_key].id, null)]
 }
 
 resource "catalystcenter_assign_devices_to_tag" "device_to_tag" {
@@ -232,11 +278,11 @@ resource "catalystcenter_assign_devices_to_tag" "device_to_tag" {
 }
 
 resource "catalystcenter_template_version" "regular_commit_version" {
-  for_each = { for template in try(concat(local.templates), []) : template.template_name => template if try(template.composite, false) == false && (var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0)) }
+  for_each = { for template in try(concat(local.templates), []) : template.resource_key => template if try(template.composite, false) == false && (var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0)) }
 
   template_id = catalystcenter_template.regular_template[each.key].id
   comments = try(md5(join("|", [
-    local.templates_content[each.key],
+    local.templates_content[each.value.template_file_name],
     jsonencode([for param in try(each.value.variables, []) : {
       parameter_name   = try(param.name, null)
       data_type        = try(param.data_type, local.defaults.catalyst_center.templates.template_params.data_type, null)
@@ -265,7 +311,7 @@ locals {
         value.software_type,
         join(",", [for item in value.containing_templates : item.id]),
         join(",", [for tmpl in local.composite_templates_map[key] : md5(join("|", [
-          local.templates_content[tmpl],
+          local.templates_content[local.templates_map[tmpl].template_file_name],
           jsonencode([for param in try(local.templates_map[tmpl].variables, []) : {
             parameter_name   = try(param.name, null)
             data_type        = try(param.data_type, local.defaults.catalyst_center.templates.template_params.data_type, null)
@@ -286,7 +332,7 @@ locals {
 }
 
 resource "catalystcenter_template_version" "composite_commit_version" {
-  for_each = { for template in try(concat(local.templates), []) : template.template_name => template if try(template.composite, false) == true && (var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0)) }
+  for_each = { for template in try(concat(local.templates), []) : template.resource_key => template if try(template.composite, false) == true && (var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0)) }
 
   template_id = catalystcenter_template.composite_template[each.key].id
   comments    = try(md5(local.composite_template_hashes[each.key]), null)
@@ -295,13 +341,13 @@ resource "catalystcenter_template_version" "composite_commit_version" {
 resource "catalystcenter_deploy_template" "regular_template_deploy" {
   for_each = {
     for tmpl, devices in local.templates_by_device : tmpl => devices
-    if try(local.templates_map[tmpl].composite, false) == false &&
-    local.templates_map[tmpl].template_type == "dayn" &&
+    if try(local.template_lookup[tmpl].composite, false) == false &&
+    local.template_lookup[tmpl].template_type == "dayn" &&
     length([for d in devices : d if strcontains(d.state, "PROVISION") && contains(local.sites, try(d.site, "NONE"))]) > 0
   }
 
-  template_id         = try(catalystcenter_template.regular_template[each.key].id, data.catalystcenter_template.template[each.key].id)
-  redeploy            = try(local.templates_map[each.key].redeploy_template, "NEVER")
+  template_id         = try(catalystcenter_template.regular_template[each.key].id, data.catalystcenter_template.template[each.key].id, data.catalystcenter_template.template[local.resource_key_to_template_key[each.key]].id)
+  redeploy            = try(local.template_lookup[each.key].redeploy_template, "NEVER")
   copying_config      = try(each.value[0].copying_config, local.defaults.catalyst_center.templates.copying_config, null)
   force_push_template = try(each.value[0].force_push_template, local.defaults.catalyst_center.templates.force_push_template, null)
   is_composite        = false
@@ -314,8 +360,8 @@ resource "catalystcenter_deploy_template" "regular_template_deploy" {
         try(lookup(local.device_ip_to_id, device.device_ip, null), null)
       )
       type                  = "MANAGED_DEVICE_UUID"
-      redeploy              = try(device.redeploy_template, local.templates_map[each.key].redeploy_template, "NEVER")
-      versioned_template_id = try(catalystcenter_template_version.regular_commit_version[each.key].id, [for v in data.catalystcenter_template_versions.template_versions[each.key].template_versions : v.id if v.version == tostring(max([for ver in data.catalystcenter_template_versions.template_versions[each.key].template_versions : ver.version != null ? tonumber(ver.version) : 0]...))][0], data.catalystcenter_template.template[device.template].id)
+      redeploy              = try(device.redeploy_template, local.template_lookup[each.key].redeploy_template, "NEVER")
+      versioned_template_id = try(catalystcenter_template_version.regular_commit_version[each.key].id, [for v in data.catalystcenter_template_versions.template_versions[try(local.resource_key_to_template_key[each.key], each.key)].template_versions : v.id if v.version == tostring(max([for ver in data.catalystcenter_template_versions.template_versions[try(local.resource_key_to_template_key[each.key], each.key)].template_versions : ver.version != null ? tonumber(ver.version) : 0]...))][0], data.catalystcenter_template.template[try(local.resource_key_to_template_key[device.template], device.template)].id)
       params = try({
         for item in local.all_devices[device.name].dayn_templates_map[device.template].variables : item.name => try(tolist(item.value), [item.value])
       }, {})
@@ -339,20 +385,20 @@ resource "catalystcenter_deploy_template" "regular_template_deploy" {
 resource "catalystcenter_deploy_template" "composite_template_deploy" {
   for_each = {
     for tmpl, devices in local.templates_by_device : tmpl => devices
-    if try(local.templates_map[tmpl].composite, false) == true &&
-    local.templates_map[tmpl].template_type == "dayn" &&
+    if try(local.template_lookup[tmpl].composite, false) == true &&
+    local.template_lookup[tmpl].template_type == "dayn" &&
     length([for d in devices : d if strcontains(d.state, "PROVISION") && contains(local.sites, try(d.site, "NONE"))]) > 0
   }
 
-  redeploy            = try(local.templates_map[each.key].redeploy_template, "NEVER")
-  template_id         = try(catalystcenter_template_version.composite_commit_version[each.key].id, [for v in data.catalystcenter_template_versions.template_versions[each.key].template_versions : v.id if v.version == tostring(max([for ver in data.catalystcenter_template_versions.template_versions[each.key].template_versions : ver.version != null ? tonumber(ver.version) : 0]...))][0], data.catalystcenter_template.template[each.key].id)
-  main_template_id    = try(catalystcenter_template.composite_template[each.key].id, data.catalystcenter_template.template[each.key].id)
-  force_push_template = try(local.templates_map[each.key].force_push_template, local.defaults.catalyst_center.templates.force_push_template, null)
+  redeploy            = try(local.template_lookup[each.key].redeploy_template, "NEVER")
+  template_id         = try(catalystcenter_template_version.composite_commit_version[each.key].id, [for v in data.catalystcenter_template_versions.template_versions[try(local.resource_key_to_template_key[each.key], each.key)].template_versions : v.id if v.version == tostring(max([for ver in data.catalystcenter_template_versions.template_versions[try(local.resource_key_to_template_key[each.key], each.key)].template_versions : ver.version != null ? tonumber(ver.version) : 0]...))][0], data.catalystcenter_template.template[try(local.resource_key_to_template_key[each.key], each.key)].id)
+  main_template_id    = try(catalystcenter_template.composite_template[each.key].id, data.catalystcenter_template.template[try(local.resource_key_to_template_key[each.key], each.key)].id)
+  force_push_template = try(local.template_lookup[each.key].force_push_template, local.defaults.catalyst_center.templates.force_push_template, null)
   is_composite        = true
 
-  member_template_deployment_info = [for tmpl in local.composite_templates_map[each.key] : {
-    template_id         = try(catalystcenter_template_version.regular_commit_version[tmpl].id, [for v in data.catalystcenter_template_versions.template_versions[tmpl].template_versions : v.id if v.version == tostring(max([for ver in data.catalystcenter_template_versions.template_versions[tmpl].template_versions : ver.version != null ? tonumber(ver.version) : 0]...))][0], data.catalystcenter_template.template[tmpl].id)
-    main_template_id    = try(catalystcenter_template.regular_template[tmpl].id, data.catalystcenter_template.template[tmpl].id)
+  member_template_deployment_info = [for tmpl in local.composite_templates_lookup[each.key] : {
+    template_id         = try(catalystcenter_template_version.regular_commit_version[tmpl].id, [for v in data.catalystcenter_template_versions.template_versions[try(local.resource_key_to_template_key[tmpl], tmpl)].template_versions : v.id if v.version == tostring(max([for ver in data.catalystcenter_template_versions.template_versions[try(local.resource_key_to_template_key[tmpl], tmpl)].template_versions : ver.version != null ? tonumber(ver.version) : 0]...))][0], data.catalystcenter_template.template[try(local.resource_key_to_template_key[tmpl], tmpl)].id)
+    main_template_id    = try(catalystcenter_template.regular_template[tmpl].id, data.catalystcenter_template.template[try(local.resource_key_to_template_key[tmpl], tmpl)].id)
     force_push_template = try(each.value[0].force_push_template, local.defaults.catalyst_center.templates.force_push_template, null)
     is_composite        = try(local.templates_map[tmpl].composite, local.defaults.catalyst_center.templates.composite, null)
     copying_config      = try(each.value[0].copying_config, local.defaults.catalyst_center.templates.copying_config, null)
@@ -366,9 +412,9 @@ resource "catalystcenter_deploy_template" "composite_template_deploy" {
           )
           type = "MANAGED_DEVICE_UUID"
 
-          redeploy = try(device.redeploy_template, local.templates_map[each.key].redeploy_template, "NEVER")
+          redeploy = try(device.redeploy_template, local.template_lookup[each.key].redeploy_template, "NEVER")
 
-          params = { for item in local.all_devices[device.name].dayn_templates_map[device.template].variables : item.name => try(tolist(item.value), [item.value]) if item.template_name == tmpl }
+          params = { for item in local.all_devices[device.name].dayn_templates_map[device.template].variables : item.name => try(tolist(item.value), [item.value]) if item.template_name == local.templates_map[tmpl].template_name }
           resource_params = [
             {
               type  = "MANAGED_DEVICE_UUID"


### PR DESCRIPTION
add support for same template name in multiple project.

if the template name is unique accross all template projects , the key for catalystcenter_template ( regular and composite template) is the template.name
but if the template name is not unqiue accross all projects, then the key is project#template.name

same also applies to catalystcenter_template_version