### PR TITLE
add wireless_fabric_multicast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Fix L2 Handoff resources being unnecessarily destroyed and recreated when removing an unrelated Anycast Gateway; `internal_vlan_id` is now ignored in lifecycle changes as it is immutable after creation in Catalyst Center
 
 **New Features:**
-- Add Wireless Profile Policy Tag support with `catalystcenter_wireless_profile_policy_tag` resource for controlling which AP Zones are active at specific sites  
+- Add Wireless Profile Policy Tag support with `catalystcenter_wireless_profile_policy_tag` resource for controlling which AP Zones are active at specific sites
+- Add `catalystcenter_wireless_fabric_multicast` resource to enable or disable wireless multicast per fabric site via `multicast.wireless_multicast_enabled`; requires a fabric WLC and fabric-enabled SSID on the site
 
 ## 0.4.2
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ module "catalystcenter" {
 | [catalystcenter_virtual_network_to_fabric_site.l3_vn_to_fabric_site](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/virtual_network_to_fabric_site) | resource |
 | [catalystcenter_virtual_network_to_fabric_site.l3_vn_to_fabric_zone](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/virtual_network_to_fabric_site) | resource |
 | [catalystcenter_wireless_device_provision.wireless_controller](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/wireless_device_provision) | resource |
+| [catalystcenter_wireless_fabric_multicast.wireless_multicast](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/wireless_fabric_multicast) | resource |
 | [catalystcenter_wireless_interface.interface](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/wireless_interface) | resource |
 | [catalystcenter_wireless_profile.wireless_profile](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/wireless_profile) | resource |
 | [catalystcenter_wireless_profile_policy_tag.policy_tag](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/wireless_profile_policy_tag) | resource |

--- a/cc_fabric.tf
+++ b/cc_fabric.tf
@@ -937,6 +937,21 @@ resource "catalystcenter_fabric_multicast_replication_mode" "replication_mode" {
   ]
 }
 
+resource "catalystcenter_wireless_fabric_multicast" "wireless_multicast" {
+  for_each = {
+    for fabric_site in try(local.catalyst_center.fabric.fabric_sites, []) :
+    fabric_site.name => try(fabric_site.multicast.wireless_multicast_enabled, null)
+    if try(fabric_site.multicast.wireless_multicast_enabled, null) != null && contains(local.sites, fabric_site.name)
+  }
+
+  fabric_id         = try(catalystcenter_fabric_site.fabric_site[each.key].id, null)
+  multicast_enabled = each.value
+
+  depends_on = [
+    catalystcenter_fabric_site.fabric_site, catalystcenter_fabric_multicast_replication_mode.replication_mode, catalystcenter_fabric_ewlc.ewlc_device, catalystcenter_fabric_device.wireless_controller
+  ]
+}
+
 locals {
   extranet_policies = flatten([
     for policy in try(local.catalyst_center.fabric.extranet_policies, []) : {


### PR DESCRIPTION
Add wireless fabric multicast support

Add catalystcenter_wireless_fabric_multicast resource in cc_fabric.tf,
sourced from catalyst_center.fabric.fabric_sites[].multicast.wireless_multicast_enabled.
Resource depends on the fabric site, replication mode, fabric eWLC, and the
wireless controller fabric device to ensure prerequisites are in place.