### PR TITLE
allow device tags without templates.tags declaration and fix system_tag drift (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Fix L2 Handoff resources being unnecessarily destroyed and recreated when removing an unrelated Anycast Gateway; `internal_vlan_id` is now ignored in lifecycle changes as it is immutable after creation in Catalyst Center
 - Fix SDA multicast over transit being incorrectly enabled for `IP_BASED_TRANSIT` type; `is_multicast_over_transit_enabled` is now only set when transit type is `SDA_LISP_PUB_SUB_TRANSIT`
 - Fix issue with assigning devices to tag while using multi state
+- Allow assigning tags to devices without requiring the tag to also be declared under `catalyst_center.templates.tags`; tag names referenced by `catalyst_center.inventory.devices[].tags` (and by template `tags` lists) are now auto-created by the module. Declaring a tag under `templates.tags` is still supported and required when richer attributes (`description`, `system_tag`, `dynamic_rules`) are needed. Note: a referenced tag that already exists in Catalyst Center but is not managed by Terraform will still cause a create conflict; declare such tags explicitly to keep them out of the module-managed set in a future release
+- Fix permanent `system_tag = false -> null` drift on `catalystcenter_tag.tag` resources whose YAML entry omits `system_tag`; the module now defaults to `false` (the Catalyst Center default for user-defined tags) so the plan converges. A one-time `+ system_tag = false` update is expected on first apply for existing managed tags
 
 **New Features:**
 - Add Wireless Profile Policy Tag support with `catalystcenter_wireless_profile_policy_tag` resource for controlling which AP Zones are active at specific sites

--- a/cc_templates.tf
+++ b/cc_templates.tf
@@ -130,6 +130,28 @@ locals {
     }
   ]
 
+  # Tags explicitly declared under catalyst_center.templates.tags, keyed by name.
+  # Preserves user-provided attributes (description, system_tag, dynamic_rules) so
+  # the auto-creation step below does not strip metadata for declared tags.
+  declared_tag_map = { for t in try(local.catalyst_center.templates.tags, []) : t.name => t }
+
+  # Tag names referenced anywhere in the data model: from inventory.devices[].tags
+  # and from any template's tags list. Used to auto-create the matching tag
+  # resource so a user can simply reference a tag on a device without also
+  # having to declare it under catalyst_center.templates.tags.
+  referenced_tag_names = distinct(concat(
+    flatten([for d in try(local.catalyst_center.inventory.devices, []) : try(d.tags, [])]),
+    [for t in local.tag_templates : t.tag_name],
+  ))
+
+  # Effective tag set the module manages: every declared tag (with full
+  # attributes) plus any referenced-but-undeclared tag synthesised as a bare
+  # { name = <name> } entry.
+  effective_tags = [
+    for name in distinct(concat(keys(local.declared_tag_map), local.referenced_tag_names)) :
+    try(local.declared_tag_map[name], { name = name })
+  ]
+
   combined_templates = flatten([
     for device in try(local.catalyst_center.inventory.devices, []) : [
       for template in concat(try(device.dayn_templates.regular, []), try(device.dayn_templates.composite, [])) : [
@@ -159,21 +181,22 @@ locals {
 }
 
 resource "catalystcenter_tag" "tag" {
-  for_each = { for tag in try(local.catalyst_center.templates.tags, []) : tag.name => tag if var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0) }
+  for_each = { for tag in local.effective_tags : tag.name => tag if var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0) }
 
-  name          = each.key
-  description   = try(each.value.description, local.defaults.catalyst_center.templates.tags.description, null)
-  system_tag    = try(each.value.system_tag, local.defaults.catalyst_center.templates.tags.sytem_tag, null)
+  name        = each.key
+  description = try(each.value.description, local.defaults.catalyst_center.templates.tags.description, null)
+  # Default to false (not null) so the config matches what Catalyst Center returns
+  # for user-defined tags; null causes a permanent "false -> null" drift on every plan.
+  system_tag    = try(each.value.system_tag, local.defaults.catalyst_center.templates.tags.system_tag, false)
   dynamic_rules = try(each.value.dynamic_rules, local.defaults.catalyst_center.templates.tags.dynamic_rules, null)
 }
 
 data "catalystcenter_tag" "device_tag" {
-  for_each = {
-    for t in try(local.devices_to_tag, []) : t.tag_name => t
-    if length(var.managed_sites) > 0
-  }
+  for_each = { for t in try(local.devices_to_tag, []) : t.tag_name => t }
 
   name = each.key
+
+  depends_on = [catalystcenter_tag.tag]
 }
 
 data "catalystcenter_project" "onboarding" {


### PR DESCRIPTION
- Auto-create catalystcenter_tag resources for tag names referenced from
  inventory.devices[].tags or any template's tags list, so a tag no longer
  has to be declared under catalyst_center.templates.tags just to assign
  it to a device. Declaring a tag under templates.tags is still supported
  and required for description / system_tag / dynamic_rules.
- Drop the multistate-only predicate (length(var.managed_sites) > 0) on
  data.catalystcenter_tag.device_tag and add depends_on = [catalystcenter_tag.tag]
  so the data-source fallback works in single-state runs too.
- Fix permanent "system_tag = false -> null" drift on catalystcenter_tag.tag
  by defaulting to false (the value Catalyst Center returns for user-defined
  tags) instead of null. A one-time "+ system_tag = false" update is expected
  on first apply for existing managed tags.
- Fix pre-existing "sytem_tag" typo in the defaults lookup.
Caveat: a tag that already exists in Catalyst Center but is not managed by
Terraform will still 4xx on create;