### PR TITLE
Fix iteration over null value in PnP image name lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.4.3 (unreleased)
 
 **New Features:**
-- Add PnP image upgrade support via `image_name` attribute; allows specifying the SWIM image by name instead of UUID, with automatic resolution to `image_id` using the `catalystcenter_images` data source (requires provider >= 0.5.15)
+- Add PnP image upgrade support via `image_name` attribute; allows specifying the SWIM image by name instead of UUID, with automatic resolution to `image_id` using the `catalystcenter_images` data source (requires provider >= 0.5.16)
 
 **Bug Fixes:**
 - Fix issue with provisioning WLC devices configured with only `secondary_managed_ap_locations`

--- a/cc_pnp.tf
+++ b/cc_pnp.tf
@@ -4,7 +4,7 @@ data "catalystcenter_images" "all_images" {
 locals {
   image_name_to_id = {
     for name, images in {
-      for image in try(data.catalystcenter_images.all_images.images, []) : image.name => image...
+      for image in coalesce(data.catalystcenter_images.all_images.images, []) : image.name => image...
     } : name => images[0].id
   }
 }


### PR DESCRIPTION
The catalystcenter_images data source returns null for images when the controller has no SWIM images, not an error — so try(..., []) does not catch it. Replace with coalesce(..., []) which converts null to [] and lets the rest of the for-expression handle the empty case cleanly.