### PR TITLE
feat: map system_settings.external_authentication to provider resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 **New Features:**
 - Add support for deploying built-in or pre-existing CLI templates that are not declared under `templates.projects[]`; reference them using the `<project_name>#<template_name>` form and the module resolves the template via Catalyst Center data sources, exactly like the existing built-in tag flow. Supported for Day-N **regular** (`inventory.devices[].dayn_templates.regular[].name`), Day-N **composite** (`inventory.devices[].dayn_templates.composite[].name`, with members and their versions discovered automatically and per-member variables matched on `template_name`), and **onboarding** (`inventory.devices[].onboarding_template.name`) templates
+- Add `system_settings.external_authentication` data model support via `catalystcenter_external_authentication` and `catalystcenter_external_authentication_aaa_attribute` resources to enable external user login and configure the custom AAA attribute for role mapping
 
 ## 0.4.3
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ module "catalystcenter" {
 | [catalystcenter_dns_settings.dns_settings](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/dns_settings) | resource |
 | [catalystcenter_dns_settings.global_dns_settings](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/dns_settings) | resource |
 | [catalystcenter_dot11be_profile.dot11be_profile](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/dot11be_profile) | resource |
+| [catalystcenter_external_authentication.external_authentication](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/external_authentication) | resource |
+| [catalystcenter_external_authentication_aaa_attribute.external_authentication](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/external_authentication_aaa_attribute) | resource |
 | [catalystcenter_extranet_policy.extranet_policy](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/extranet_policy) | resource |
 | [catalystcenter_fabric_device.border_device](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/fabric_device) | resource |
 | [catalystcenter_fabric_device.edge_device](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/fabric_device) | resource |

--- a/cc_system_settings.tf
+++ b/cc_system_settings.tf
@@ -58,3 +58,25 @@ resource "catalystcenter_authentication_policy_server" "aaa" {
   encryption_key      = can(each.value.protocols.radius.enable_key_wrap) ? try(each.value.protocols.radius.enable_key_wrap.encryption_key, local.defaults.catalyst_center.system_settings.authentication_and_policy_servers.aaa.protocols.radius.enable_key_wrap.encryption_key, null) : null
   message_key         = can(each.value.protocols.radius.enable_key_wrap) ? try(each.value.protocols.radius.enable_key_wrap.message_key, local.defaults.catalyst_center.system_settings.authentication_and_policy_servers.aaa.protocols.radius.enable_key_wrap.message_key, null) : null
 }
+
+resource "catalystcenter_external_authentication" "external_authentication" {
+
+  count = try(local.catalyst_center.system_settings.external_authentication, null) != null && (var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0)) ? 1 : 0
+
+  name    = "external_authentication"
+  enabled = try(local.catalyst_center.system_settings.external_authentication.enabled, local.defaults.catalyst_center.system_settings.external_authentication.enabled, false)
+
+  depends_on = [
+    catalystcenter_authentication_policy_server.ise,
+    catalystcenter_authentication_policy_server.aaa,
+  ]
+}
+
+resource "catalystcenter_external_authentication_aaa_attribute" "external_authentication" {
+
+  count = try(local.catalyst_center.system_settings.external_authentication.aaa_attribute, null) != null && (var.manage_global_settings || (!var.manage_global_settings && length(var.managed_sites) == 0)) ? 1 : 0
+
+  name = try(local.catalyst_center.system_settings.external_authentication.aaa_attribute, local.defaults.catalyst_center.system_settings.external_authentication.aaa_attribute, null)
+
+  depends_on = [catalystcenter_external_authentication.external_authentication]
+}


### PR DESCRIPTION
Wire external_authentication (+ aaa_attribute) into cc_system_settings.tf,
depending on authentication_policy_server resources. Fixes #463.