### PR TITLE
add WLC and EWLC pre-condition validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ module "catalystcenter" {
 | [terraform_data.bulk_site_provisioning_validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.managed_sites_validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.wireless_validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [time_sleep.provision_device_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.template_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.wait_for_managed_ap_locations](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |

--- a/cc_device_provision.tf
+++ b/cc_device_provision.tf
@@ -148,12 +148,50 @@ locals {
   ]
 
   missing_devices_error = length(local.missing_devices) > 0 ? "❌ The following devices are not found in Catalyst Center inventory:\n\n${join("\n", [for d in local.missing_devices : "  • ${d.name} (IP: ${try(d.device_ip, "N/A")}, FQDN: ${try(d.fqdn_name, "N/A")}, Site: ${d.site})"])}\n\nAction required: Ensure all devices are discovered in Catalyst Center before running Terraform." : ""
+
+  wireless_role_invariant_violations = [
+    for device in try(local.catalyst_center.inventory.devices, []) :
+    device
+    if(try(device.primary_managed_ap_locations, null) != null || try(device.secondary_managed_ap_locations, null) != null)
+    && !(
+      contains(coalesce(try(device.fabric_roles, []), []), "EMBEDDED_WIRELESS_CONTROLLER_NODE") !=
+      contains(coalesce(try(device.fabric_roles, []), []), "WIRELESS_CONTROLLER_NODE")
+    )
+  ]
+
+  wireless_role_invariant_error = length(local.wireless_role_invariant_violations) > 0 ? "❌ The following devices have managed AP locations but do not carry exactly one wireless-controller role:\n\n${join("\n", [for d in local.wireless_role_invariant_violations : "  • ${d.name} (roles: ${join(", ", coalesce(try(d.fabric_roles, []), []))})"])}\n\nA device with primary_managed_ap_locations or secondary_managed_ap_locations MUST contain exactly one of EMBEDDED_WIRELESS_CONTROLLER_NODE or WIRELESS_CONTROLLER_NODE (never both, never neither).\n\nAction required: Add the appropriate wireless-controller role, or remove the managed AP locations, so each wireless device is exactly one kind of controller." : ""
+
+  wireless_controller_missing_ap_locations = [
+    for device in try(local.catalyst_center.inventory.devices, []) :
+    device
+    if(
+      contains(coalesce(try(device.fabric_roles, []), []), "EMBEDDED_WIRELESS_CONTROLLER_NODE") ||
+      contains(coalesce(try(device.fabric_roles, []), []), "WIRELESS_CONTROLLER_NODE")
+    )
+    && try(device.primary_managed_ap_locations, null) == null
+    && try(device.secondary_managed_ap_locations, null) == null
+  ]
+
+  wireless_controller_missing_ap_locations_error = length(local.wireless_controller_missing_ap_locations) > 0 ? "❌ The following devices carry a wireless-controller role but have no managed AP locations:\n\n${join("\n", [for d in local.wireless_controller_missing_ap_locations : "  • ${d.name} (roles: ${join(", ", coalesce(try(d.fabric_roles, []), []))})"])}\n\nA device with EMBEDDED_WIRELESS_CONTROLLER_NODE or WIRELESS_CONTROLLER_NODE MUST have at least one of primary_managed_ap_locations or secondary_managed_ap_locations.\n\nAction required: Add primary_managed_ap_locations (and/or secondary_managed_ap_locations), or remove the wireless-controller role if the device is not a controller." : ""
 }
 
 check "device_discovery_validation" {
   assert {
     condition     = length(local.missing_devices) == 0
     error_message = local.missing_devices_error
+  }
+}
+
+resource "terraform_data" "wireless_validation" {
+  lifecycle {
+    precondition {
+      condition     = length(local.wireless_role_invariant_violations) == 0
+      error_message = local.wireless_role_invariant_error
+    }
+    precondition {
+      condition     = length(local.wireless_controller_missing_ap_locations) == 0
+      error_message = local.wireless_controller_missing_ap_locations_error
+    }
   }
 }
 

--- a/cc_device_provision.tf
+++ b/cc_device_provision.tf
@@ -149,30 +149,43 @@ locals {
 
   missing_devices_error = length(local.missing_devices) > 0 ? "❌ The following devices are not found in Catalyst Center inventory:\n\n${join("\n", [for d in local.missing_devices : "  • ${d.name} (IP: ${try(d.device_ip, "N/A")}, FQDN: ${try(d.fqdn_name, "N/A")}, Site: ${d.site})"])}\n\nAction required: Ensure all devices are discovered in Catalyst Center before running Terraform." : ""
 
-  wireless_role_invariant_violations = [
-    for device in try(local.catalyst_center.inventory.devices, []) :
-    device
-    if(try(device.primary_managed_ap_locations, null) != null || try(device.secondary_managed_ap_locations, null) != null)
-    && !(
-      contains(coalesce(try(device.fabric_roles, []), []), "EMBEDDED_WIRELESS_CONTROLLER_NODE") !=
-      contains(coalesce(try(device.fabric_roles, []), []), "WIRELESS_CONTROLLER_NODE")
-    )
+  # Devices Terraform will actually provision — same scope as the AP-location /
+  # controller resources, so the guard fires only when the destructive delete is
+  # possible.
+  provisioned_wireless_candidate_devices = [
+    for device in try(local.catalyst_center.inventory.devices, []) : device
+    if strcontains(try(device.state, ""), "PROVISION") || try(device.state, "") == "MARK_FOR_REPLACEMENT"
   ]
 
-  wireless_role_invariant_error = length(local.wireless_role_invariant_violations) > 0 ? "❌ The following devices have managed AP locations but do not carry exactly one wireless-controller role:\n\n${join("\n", [for d in local.wireless_role_invariant_violations : "  • ${d.name} (roles: ${join(", ", coalesce(try(d.fabric_roles, []), []))})"])}\n\nA device with primary_managed_ap_locations or secondary_managed_ap_locations MUST contain exactly one of EMBEDDED_WIRELESS_CONTROLLER_NODE or WIRELESS_CONTROLLER_NODE (never both, never neither).\n\nAction required: Add the appropriate wireless-controller role, or remove the managed AP locations, so each wireless device is exactly one kind of controller." : ""
+  # Per-device wireless facts, computed once to avoid repeating the
+  # contains(coalesce(try(...))) role lookups.
+  wireless_device_facts = [
+    for device in local.provisioned_wireless_candidate_devices : {
+      name         = device.name
+      roles        = coalesce(try(device.fabric_roles, []), [])
+      has_embedded = contains(coalesce(try(device.fabric_roles, []), []), "EMBEDDED_WIRELESS_CONTROLLER_NODE")
+      has_wlc      = contains(coalesce(try(device.fabric_roles, []), []), "WIRELESS_CONTROLLER_NODE")
+      has_ap_locs  = try(device.primary_managed_ap_locations, null) != null || try(device.secondary_managed_ap_locations, null) != null
+    }
+  ]
 
+  # Rule: a device WITH managed AP locations must carry exactly one controller
+  # role. `has_embedded == has_wlc` means both roles or neither → invalid.
+  wireless_devices_with_invalid_controller_role = [
+    for d in local.wireless_device_facts : d
+    if d.has_ap_locs && (d.has_embedded == d.has_wlc)
+  ]
+
+  wireless_invalid_controller_role_error = length(local.wireless_devices_with_invalid_controller_role) > 0 ? "❌ The following devices have managed AP locations but do not carry exactly one wireless-controller role:\n\n${join("\n", [for d in local.wireless_devices_with_invalid_controller_role : "  • ${d.name} (roles: ${join(", ", d.roles)})"])}\n\nA device with primary_managed_ap_locations or secondary_managed_ap_locations MUST contain exactly one of EMBEDDED_WIRELESS_CONTROLLER_NODE or WIRELESS_CONTROLLER_NODE (never both, never neither).\n\nAction required: Add the appropriate wireless-controller role, or remove the managed AP locations, so each wireless device is exactly one kind of controller." : ""
+
+  # Rule: a device WITH a controller role must have at least one managed AP
+  # location.
   wireless_controller_missing_ap_locations = [
-    for device in try(local.catalyst_center.inventory.devices, []) :
-    device
-    if(
-      contains(coalesce(try(device.fabric_roles, []), []), "EMBEDDED_WIRELESS_CONTROLLER_NODE") ||
-      contains(coalesce(try(device.fabric_roles, []), []), "WIRELESS_CONTROLLER_NODE")
-    )
-    && try(device.primary_managed_ap_locations, null) == null
-    && try(device.secondary_managed_ap_locations, null) == null
+    for d in local.wireless_device_facts : d
+    if(d.has_embedded || d.has_wlc) && !d.has_ap_locs
   ]
 
-  wireless_controller_missing_ap_locations_error = length(local.wireless_controller_missing_ap_locations) > 0 ? "❌ The following devices carry a wireless-controller role but have no managed AP locations:\n\n${join("\n", [for d in local.wireless_controller_missing_ap_locations : "  • ${d.name} (roles: ${join(", ", coalesce(try(d.fabric_roles, []), []))})"])}\n\nA device with EMBEDDED_WIRELESS_CONTROLLER_NODE or WIRELESS_CONTROLLER_NODE MUST have at least one of primary_managed_ap_locations or secondary_managed_ap_locations.\n\nAction required: Add primary_managed_ap_locations (and/or secondary_managed_ap_locations), or remove the wireless-controller role if the device is not a controller." : ""
+  wireless_controller_missing_ap_locations_error = length(local.wireless_controller_missing_ap_locations) > 0 ? "❌ The following devices carry a wireless-controller role but have no managed AP locations:\n\n${join("\n", [for d in local.wireless_controller_missing_ap_locations : "  • ${d.name} (roles: ${join(", ", d.roles)})"])}\n\nA device with EMBEDDED_WIRELESS_CONTROLLER_NODE or WIRELESS_CONTROLLER_NODE MUST have at least one of primary_managed_ap_locations or secondary_managed_ap_locations.\n\nAction required: Add primary_managed_ap_locations (and/or secondary_managed_ap_locations), or remove the wireless-controller role if the device is not a controller." : ""
 }
 
 check "device_discovery_validation" {
@@ -185,8 +198,8 @@ check "device_discovery_validation" {
 resource "terraform_data" "wireless_validation" {
   lifecycle {
     precondition {
-      condition     = length(local.wireless_role_invariant_violations) == 0
-      error_message = local.wireless_role_invariant_error
+      condition     = length(local.wireless_devices_with_invalid_controller_role) == 0
+      error_message = local.wireless_invalid_controller_role_error
     }
     precondition {
       condition     = length(local.wireless_controller_missing_ap_locations) == 0


### PR DESCRIPTION
add wirelss role condition checks to prevent deleting an EWLC device when only the EMBEDDED_WIRELESS_CONTROLLER_NODE" role is removed and keep the AP managed location in the data model