### PR TITLE
Wire LAN automation links to catalystcenter_lan_automation_link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.4.5 (unreleased)
+
+**Bug Fixes:**
+-  Improve the managed-AP-location controller-role validation, so it covers both Fabric and non-Fabric use cases 
+
+**New Features:**
+- Restructure LAN Automation data model into `lan_automation.devices[]` (device discovery sessions) and `lan_automation.links[]` (DAY-N link add/delete operations with `ADD_LINK` / `DELETE_LINK` actions) via new `catalystcenter_lan_automation_link` provider resource
+
+**Breaking Changes:**
+- `catalyst_center.lan_automation` is no longer a flat list; migrate device entries under `lan_automation.devices` (remove `type: devices`) and link entries under `lan_automation.links` with `action: ADD_LINK` or `DELETE_LINK` (remove `type: link` and `status: START`)
+
 ## 0.4.4
 
 **Bug Fixes:**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ catalyst_center:
 ```hcl
 module "catalystcenter" {
   source  = "netascode/nac-catalystcenter/catalystcenter"
-  version = "0.4.4"
+  version = "0.4.5"
 
   yaml_files = ["area.yaml"]
 }
@@ -38,7 +38,7 @@ module "catalystcenter" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_catalystcenter"></a> [catalystcenter](#requirement\_catalystcenter) | ~> 0.5.22 |
+| <a name="requirement_catalystcenter"></a> [catalystcenter](#requirement\_catalystcenter) | ~> 0.5.23 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.3.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.12.1 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 1.0.0 |
@@ -151,7 +151,7 @@ module "catalystcenter" {
 | [catalystcenter_ip_pool.ip_pool_v6](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/ip_pool) | resource |
 | [catalystcenter_ip_pool_reservation.pool_reservation](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/ip_pool_reservation) | resource |
 | [catalystcenter_lan_automation.lanauto_edge](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/lan_automation) | resource |
-| [catalystcenter_lan_automation.lanauto_link](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/lan_automation) | resource |
+| [catalystcenter_lan_automation_link.link](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/lan_automation_link) | resource |
 | [catalystcenter_network_profile.switching_network_profile](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/network_profile) | resource |
 | [catalystcenter_network_profile_for_sites_assignments.site_to_network_profile](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/network_profile_for_sites_assignments) | resource |
 | [catalystcenter_network_profile_for_sites_assignments.site_to_wireless_network_profile](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/resources/network_profile_for_sites_assignments) | resource |

--- a/cc_lan_automation.tf
+++ b/cc_lan_automation.tf
@@ -1,37 +1,40 @@
-resource "catalystcenter_lan_automation" "lanauto_link" {
-  for_each = { for lanauto in try(local.catalyst_center.lan_automation, []) : lanauto.name => lanauto if lanauto.type == "link" && lanauto.status == "START" }
+resource "catalystcenter_lan_automation_link" "link" {
+  for_each = {
+    for link in try(local.catalyst_center.lan_automation.links, []) :
+    "${link.name}#_#${link.action}" => link
+    if contains(["ADD_LINK", "DELETE_LINK"], try(link.action, ""))
+  }
 
-  discovered_device_site_name_hierarchy = try(each.value.discovered_device_site_name_hierarchy, local.defaults.catalyst_center.lan_automation.discovered_device_site_name_hierarchy, null)
-  primary_device_management_ip_address  = try(each.value.primary_device_management_ip_address, local.defaults.catalyst_center.lan_automation.primary_device_management_ip_address, null)
-  peer_device_management_ip_address     = try(each.value.secondary_device_management_ip_address, local.defaults.catalyst_center.lan_automation.secondary_device_management_ip_address, null)
-  primary_device_interface_names        = try(each.value.primary_device_interface_names, local.defaults.catalyst_center.lan_automation.primary_device_interface_names, null)
-  ip_pools = [for pool in try(each.value.ip_pools, []) : {
-    "ip_pool_name" : pool.name
-    "ip_pool_role" : pool.role == "PRINCIPAL_IP_ADDRESS_POOL" ? "MAIN_POOL" : pool.role == "LINK_OVERLAPPING_IP_POOL" ? "PHYSICAL_LINK_POOL" : null
-  }]
-  multicast_enabled        = try(each.value.multicast_enabled, local.defaults.catalyst_center.lan_automation.multicast_enabled, null)
-  redistribute_isis_to_bgp = try(each.value.advertise_lan_automation_routes_into_bgp, local.defaults.catalyst_center.lan_automation.advertise_lan_automation_routes_into_bgp, null)
-  isis_domain_password     = try(each.value.isis_domain_password, local.defaults.catalyst_center.lan_automation.isis_domain_password, null)
+  action                               = try(each.value.action, local.defaults.catalyst_center.lan_automation.links.action, null)
+  primary_device_management_ip_address = try(each.value.primary_device_management_ip_address, local.defaults.catalyst_center.lan_automation.links.primary_device_management_ip_address, null)
+  primary_device_interface_name        = try(each.value.primary_device_interface_name, local.defaults.catalyst_center.lan_automation.links.primary_device_interface_name, null)
+  peer_device_management_ip_address    = try(each.value.secondary_device_management_ip_address, local.defaults.catalyst_center.lan_automation.links.secondary_device_management_ip_address, null)
+  peer_device_interface_name           = try(each.value.secondary_device_interface_name, local.defaults.catalyst_center.lan_automation.links.secondary_device_interface_name, null)
+  ip_pool_name                         = try(each.value.ip_pool_name, local.defaults.catalyst_center.lan_automation.links.ip_pool_name, null)
 }
 
 resource "catalystcenter_lan_automation" "lanauto_edge" {
-  for_each = { for lanauto in try(local.catalyst_center.lan_automation, []) : lanauto.name => lanauto if lanauto.type == "devices" && lanauto.status == "START" }
+  for_each = {
+    for lanauto in try(local.catalyst_center.lan_automation.devices, []) :
+    lanauto.name => lanauto
+    if try(lanauto.status, "") == "START"
+  }
 
-  discovered_device_site_name_hierarchy = try(each.value.discovered_device_site_name_hierarchy, local.defaults.catalyst_center.lan_automation.discovered_device_site_name_hierarchy, null)
-  primary_device_management_ip_address  = try(each.value.primary_device_management_ip_address, local.defaults.catalyst_center.lan_automation.primary_device_management_ip_address, null)
-  peer_device_management_ip_address     = try(each.value.secondary_device_management_ip_address, local.defaults.catalyst_center.lan_automation.secondary_device_management_ip_address, null)
-  primary_device_interface_names        = try(each.value.primary_device_interface_names, local.defaults.catalyst_center.lan_automation.primary_device_interface_names, null)
+  discovered_device_site_name_hierarchy = try(each.value.discovered_device_site_name_hierarchy, local.defaults.catalyst_center.lan_automation.devices.discovered_device_site_name_hierarchy, null)
+  primary_device_management_ip_address  = try(each.value.primary_device_management_ip_address, local.defaults.catalyst_center.lan_automation.devices.primary_device_management_ip_address, null)
+  peer_device_management_ip_address     = try(each.value.secondary_device_management_ip_address, local.defaults.catalyst_center.lan_automation.devices.secondary_device_management_ip_address, null)
+  primary_device_interface_names        = try(each.value.primary_device_interface_names, local.defaults.catalyst_center.lan_automation.devices.primary_device_interface_names, null)
   ip_pools = [for pool in try(each.value.ip_pools, []) : {
     "ip_pool_name" : pool.name
     "ip_pool_role" : pool.role == "PRINCIPAL_IP_ADDRESS_POOL" ? "MAIN_POOL" : pool.role == "LINK_OVERLAPPING_IP_POOL" ? "PHYSICAL_LINK_POOL" : null
   }]
-  multicast_enabled        = try(each.value.multicast_enabled, local.defaults.catalyst_center.lan_automation.multicast_enabled, null)
-  redistribute_isis_to_bgp = try(each.value.advertise_lan_automation_routes_into_bgp, local.defaults.catalyst_center.lan_automation.advertise_lan_automation_routes_into_bgp, null)
-  isis_domain_password     = try(each.value.isis_domain_password, local.defaults.catalyst_center.lan_automation.isis_domain_password, null)
-  host_name_prefix         = try(each.value.host_name_prefix, local.defaults.catalyst_center.lan_automation.host_name_prefix, null)
-  discovery_level          = try(each.value.discovery_level, local.defaults.catalyst_center.lan_automation.discovery_level, null)
-  discovery_devices        = try(each.value.discovery_devices, local.defaults.catalyst_center.lan_automation.discovery_devices, null)
-  discovery_timeout        = try(each.value.discovery_timeout, local.defaults.catalyst_center.lan_automation.discovery_timeout, null)
+  multicast_enabled        = try(each.value.multicast_enabled, local.defaults.catalyst_center.lan_automation.devices.multicast_enabled, null)
+  redistribute_isis_to_bgp = try(each.value.advertise_lan_automation_routes_into_bgp, local.defaults.catalyst_center.lan_automation.devices.advertise_lan_automation_routes_into_bgp, null)
+  isis_domain_password     = try(each.value.isis_domain_password, local.defaults.catalyst_center.lan_automation.devices.isis_domain_password, null)
+  host_name_prefix         = try(each.value.host_name_prefix, local.defaults.catalyst_center.lan_automation.devices.host_name_prefix, null)
+  discovery_level          = try(each.value.discovery_level, local.defaults.catalyst_center.lan_automation.devices.discovery_level, null)
+  discovery_devices        = try(each.value.discovery_devices, local.defaults.catalyst_center.lan_automation.devices.discovery_devices, null)
+  discovery_timeout        = try(each.value.discovery_timeout, local.defaults.catalyst_center.lan_automation.devices.discovery_timeout, null)
 
   depends_on = [catalystcenter_ip_pool_reservation.pool_reservation]
 }

--- a/examples/site/README.md
+++ b/examples/site/README.md
@@ -35,7 +35,7 @@ catalyst_center:
 ```hcl
 module "catalystcenter" {
   source  = "netascode/nac-catalystcenter/catalystcenter"
-  version = "0.4.4"
+  version = "0.4.5"
 
   yaml_files = ["area.yaml"]
 }

--- a/examples/site/main.tf
+++ b/examples/site/main.tf
@@ -1,6 +1,6 @@
 module "catalystcenter" {
   source  = "netascode/nac-catalystcenter/catalystcenter"
-  version = "0.4.4"
+  version = "0.4.5"
 
   yaml_files = ["area.yaml"]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     catalystcenter = {
       source  = "CiscoDevNet/catalystcenter"
-      version = "~> 0.5.22"
+      version = "~> 0.5.23"
     }
     utils = {
       source  = "netascode/utils"


### PR DESCRIPTION
Split module mapping into lan_automation.devices (existing discovery sessions)
and lan_automation.links (ADD_LINK / DELETE_LINK). Remove the broken lanauto_link
block that incorrectly used catalystcenter_lan_automation for link workflows.

Refs: netascode/nac-catalystcenter#474