### PR TITLE
fix add port-assignment dependency for non-bulk path

### DIFF
--- a/cc_fabric.tf
+++ b/cc_fabric.tf
@@ -940,7 +940,7 @@ resource "catalystcenter_fabric_port_assignments" "port_assignments" {
   )
   port_assignments = try(local.device_port_assignments[each.key], null)
 
-  depends_on = [catalystcenter_fabric_device.edge_device, catalystcenter_fabric_device.border_device, catalystcenter_fabric_devices.fabric_devices, catalystcenter_fabric_devices.fabric_devices_zone, catalystcenter_provision_devices.provision_devices, catalystcenter_provision_device.provision_device, catalystcenter_anycast_gateway.anycast_gateway, catalystcenter_anycast_gateways.anycast_gateways, catalystcenter_anycast_gateways.anycast_gateways_zone]
+  depends_on = [catalystcenter_fabric_device.edge_device, catalystcenter_fabric_device.border_device, catalystcenter_fabric_devices.fabric_devices, catalystcenter_fabric_devices.fabric_devices_zone, catalystcenter_provision_devices.provision_devices, catalystcenter_provision_device.provision_device, catalystcenter_anycast_gateway.anycast_gateway, catalystcenter_anycast_gateway.anycast_gateway_zone, catalystcenter_anycast_gateways.anycast_gateways, catalystcenter_anycast_gateways.anycast_gateways_zone]
 }
 
 


### PR DESCRIPTION
add port-assignment dependency on anycast_gateway.anycast_gateway_zone eliminating the NCHS20144 … Data Vlan Name …-BYOD is not valid for interface race for fabric-zone edge devices