### PR TITLE
Add create_per_site flag to create transits in per-site mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.6 (unreleased)
+
+**New Features:**
+- Add `fabric.transits[].create_per_site` opt-in flag so a per-site `IP_BASED_TRANSIT` defined in site data is created via `catalystcenter_transit_network` even in per-site mode (`manage_global_settings = false` with a non-empty `managed_sites`). Flagged transit names are excluded from the `catalystcenter_transit_network` data source lookup so it no longer errors reading a not-yet-created transit. The flag is honored only for `IP_BASED_TRANSIT` (which needs no control-plane devices); SDA transit types ignore it and remain global/lookup-only. Transits without the flag keep the existing behavior (created only in a global apply and referenced per-site).
+
 ## 0.4.5
 
 **Bug Fixes:**

--- a/cc_fabric.tf
+++ b/cc_fabric.tf
@@ -172,17 +172,23 @@ locals {
 }
 
 data "catalystcenter_transit_network" "transit" {
-  for_each = var.manage_global_settings == false && length(var.managed_sites) != 0 ? toset([for transit in try(local.catalyst_center.fabric.transits, []) : transit.name]) : toset([])
+  # `create_per_site` is only honored for IP_BASED_TRANSIT (see resource below); only those
+  # flagged transits are excluded from the lookup, everything else is still read by name.
+  for_each = var.manage_global_settings == false && length(var.managed_sites) != 0 ? toset([for transit in try(local.catalyst_center.fabric.transits, []) : transit.name if !(try(transit.create_per_site, false) && try(transit.type, local.defaults.catalyst_center.fabric.transits.type, "") == "IP_BASED_TRANSIT")]) : toset([])
 
   name = each.key
 }
 
 resource "catalystcenter_transit_network" "transit" {
-  for_each = { for transit in try(local.catalyst_center.fabric.transits, []) : transit.name => transit if var.manage_global_settings &&
+  # Per-site creation (`create_per_site`) is intentionally limited to IP_BASED_TRANSIT: it needs no
+  # control-plane devices, so it is safe to create from a site state. SDA transits require provisioned
+  # control-plane devices (see the manage_global_settings branch) and remain global/lookup-only.
+  for_each = { for transit in try(local.catalyst_center.fabric.transits, []) : transit.name => transit if(var.manage_global_settings &&
     alltrue([
       for device in try(transit.control_plane_devices, []) :
       contains(local.provisioned_sda_transit_cp_devices, device)
-    ]) || (!var.manage_global_settings && length(var.managed_sites) == 0)
+    ])) || (!var.manage_global_settings && length(var.managed_sites) == 0) ||
+    (!var.manage_global_settings && length(var.managed_sites) != 0 && try(transit.create_per_site, false) && try(transit.type, local.defaults.catalyst_center.fabric.transits.type, "") == "IP_BASED_TRANSIT")
   }
 
   name                              = each.key


### PR DESCRIPTION
Previously transits were treated as global-only objects: created in a
global apply and merely looked up (via data source) in per-site applies
(manage_global_settings = false with a non-empty managed_sites). A transit
defined in site data was therefore never created, and forcing it broke the
companion data source, which errored reading a not-yet-created transit.

Add an opt-in fabric.transits[].create_per_site flag:
- resource for_each now also creates the transit in per-site mode when the
  flag is set (e.g. a unique per-site IP_BASED_TRANSIT).
- data source for_each excludes flagged transit names so it no longer
  reads a transit that this state is about to create.
Transits without the flag keep the existing behavior exactly.
Refs: netascode/nac-catalystcenter#465