### PR TITLE
Rework RMA into 3-step rma-block workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 **Bug Fixes:**
 - Fix a create-time race condition (`NCHS20215`) when a fabric-zone anycast gateway is created for an anchored virtual network on a non-anchor (inheriting) site; the zone anycast gateway resources now depend on their corresponding anchoring site-level anycast gateway resources so the fabric-site gateway is always created first
+- Fix `Invalid for_each argument` error during `terraform import`/plan on setups with provisioned devices by redesigning the RMA workflow so that all `catalystcenter_device_replacement` / `catalystcenter_device_replacement_workflow` `for_each` keys derive only from static data-model values instead of an apply-time-unknown data source
+
+**Breaking Changes:**
+- Rework the RMA (Return Material Authorization) device replacement workflow into a 3-step process driven by a new `inventory.devices[].rma` block (`action: MARK_FOR_REPLACEMENT` then `action: REPLACE` with `replacement_serial_number`, then remove the block). The device `state` now stays `PROVISION` throughout a replacement, so the `MARK_FOR_REPLACEMENT` device `state` value is removed. Migrate any device using `state: MARK_FOR_REPLACEMENT` to `state: PROVISION` with the corresponding `rma` block
 
 ## 0.4.6
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ module "catalystcenter" {
 | [catalystcenter_credentials_snmpv2_read.multi_state_non_global_credentials](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/credentials_snmpv2_read) | data source |
 | [catalystcenter_credentials_snmpv2_write.multi_state_non_global_credentials](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/credentials_snmpv2_write) | data source |
 | [catalystcenter_credentials_snmpv3.multi_state_non_global_credentials](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/credentials_snmpv3) | data source |
-| [catalystcenter_device_replacement.rma_device](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/device_replacement) | data source |
 | [catalystcenter_dot11be_profile.dot11be_profile](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/dot11be_profile) | data source |
 | [catalystcenter_fabric_l2_virtual_network.l2_vn_zone_parent](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/fabric_l2_virtual_network) | data source |
 | [catalystcenter_fabric_l3_virtual_network.l3_vn](https://registry.terraform.io/providers/CiscoDevNet/catalystcenter/latest/docs/data-sources/fabric_l3_virtual_network) | data source |

--- a/cc_device_provision.tf
+++ b/cc_device_provision.tf
@@ -38,11 +38,11 @@ locals {
   }
 
   provisioned_devices = [
-    for device in try(local.catalyst_center.inventory.devices, []) : device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && ((try(device.primary_managed_ap_locations, null) == null && try(device.secondary_managed_ap_locations, null) == null && !contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE") && !contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE")) || ((try(device.primary_managed_ap_locations, null) != null || try(device.secondary_managed_ap_locations, null) != null) && contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE"))) && contains(local.sites, try(device.site, "NONE"))
+    for device in try(local.catalyst_center.inventory.devices, []) : device if(strcontains(device.state, "PROVISION")) && ((try(device.primary_managed_ap_locations, null) == null && try(device.secondary_managed_ap_locations, null) == null && !contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE") && !contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE")) || ((try(device.primary_managed_ap_locations, null) != null || try(device.secondary_managed_ap_locations, null) != null) && contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE"))) && contains(local.sites, try(device.site, "NONE"))
   ]
 
   all_provisioned_devices = [
-    for device in try(local.catalyst_center.inventory.devices, []) : device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && try(device.primary_managed_ap_locations, null) == null
+    for device in try(local.catalyst_center.inventory.devices, []) : device if(strcontains(device.state, "PROVISION")) && try(device.primary_managed_ap_locations, null) == null
   ]
 
   provisioned_devices_filtered = [
@@ -110,7 +110,7 @@ locals {
       name      = d.name
       fqdn_name = d.fqdn_name
       device_ip = try(d.device_ip, null)
-    }... if(strcontains(d.state, "PROVISION") || d.state == "ASSIGN" || d.state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(d.site, "NONE")) && try(d.type, null) == "AccessPoint"
+    }... if(strcontains(d.state, "PROVISION") || d.state == "ASSIGN") && contains(local.sites, try(d.site, "NONE")) && try(d.type, null) == "AccessPoint"
     && (
       lookup(local.device_name_to_id, d.name, null) != null ||
       lookup(local.device_name_to_id, try(d.fqdn_name, ""), null) != null ||
@@ -124,7 +124,7 @@ locals {
       name      = d.name
       fqdn_name = d.fqdn_name
       device_ip = try(d.device_ip, null)
-    }... if(strcontains(d.state, "PROVISION") || d.state == "MARK_FOR_REPLACEMENT") && (try(d.primary_managed_ap_locations, null) != null || try(d.secondary_managed_ap_locations, null) != null) && !contains(try(d.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE") && contains(local.sites, try(d.site, "NONE"))
+    }... if(strcontains(d.state, "PROVISION")) && (try(d.primary_managed_ap_locations, null) != null || try(d.secondary_managed_ap_locations, null) != null) && !contains(try(d.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE") && contains(local.sites, try(d.site, "NONE"))
     && (
       lookup(local.device_name_to_id, d.name, null) != null ||
       lookup(local.device_name_to_id, try(d.fqdn_name, ""), null) != null ||
@@ -140,7 +140,7 @@ locals {
   missing_devices = [
     for device in try(local.catalyst_center.inventory.devices, []) :
     device
-    if(strcontains(device.state, "PROVISION") || device.state == "ASSIGN" || device.state == "MARK_FOR_REPLACEMENT")
+    if(strcontains(device.state, "PROVISION") || device.state == "ASSIGN")
     && try(device.type, null) != "AccessPoint"
     && lookup(local.device_name_to_id, device.name, null) == null
     && lookup(local.device_name_to_id, try(device.fqdn_name, ""), null) == null
@@ -154,8 +154,7 @@ locals {
   # possible.
   provisioned_wireless_candidate_devices = [
     for device in try(local.catalyst_center.inventory.devices, []) : device
-    if strcontains(try(device.state, ""), "PROVISION") || try(device.state, "") == "MARK_FOR_REPLACEMENT"
-  ]
+  if strcontains(try(device.state, ""), "PROVISION")]
 
   # Per-device wireless facts, computed once to avoid repeating the
   # contains(coalesce(try(...))) role lookups.
@@ -287,7 +286,7 @@ resource "catalystcenter_device_role" "role" {
   for_each = {
     for device in try(local.catalyst_center.inventory.devices, []) :
     device.name => device
-    if(strcontains(device.state, "PROVISION") || device.state == "ASSIGN" || device.state == "MARK_FOR_REPLACEMENT")
+    if(strcontains(device.state, "PROVISION") || device.state == "ASSIGN")
     && contains(local.sites, try(device.site, "NONE"))
     && try(device.type, null) != "AccessPoint"
     && (
@@ -309,7 +308,7 @@ resource "catalystcenter_device_role" "role" {
 }
 
 resource "catalystcenter_provision_device" "provision_device" {
-  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && ((try(device.primary_managed_ap_locations, null) == null && try(device.secondary_managed_ap_locations, null) == null && !contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE") && !contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE")) || ((try(device.primary_managed_ap_locations, null) != null || try(device.secondary_managed_ap_locations, null) != null) && contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE"))) && contains(local.sites, try(device.site, "NONE")) && var.use_bulk_api == false && try(device.type, null) != "AccessPoint" }
+  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION")) && ((try(device.primary_managed_ap_locations, null) == null && try(device.secondary_managed_ap_locations, null) == null && !contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE") && !contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE")) || ((try(device.primary_managed_ap_locations, null) != null || try(device.secondary_managed_ap_locations, null) != null) && contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE"))) && contains(local.sites, try(device.site, "NONE")) && var.use_bulk_api == false && try(device.type, null) != "AccessPoint" }
 
   site_id           = var.use_bulk_api ? coalesce(local.site_id_list_bulk[each.value.site], local.data_source_created_sites_list[each.value.site]) : local.site_id_list[each.value.site]
   network_device_id = try(local.device_name_to_id[each.value.name], local.device_name_to_id[each.value.fqdn_name], local.device_ip_to_id[each.value.device_ip])
@@ -360,7 +359,7 @@ resource "catalystcenter_assign_device_to_site" "wireless_devices_to_site" {
 }
 
 resource "catalystcenter_wireless_device_provision" "wireless_controller" {
-  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && (contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE") || try(device.primary_managed_ap_locations, null) != null || try(device.secondary_managed_ap_locations, null) != null) && !contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE") && contains(local.sites, try(device.site, "NONE")) }
+  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION")) && (contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE") || try(device.primary_managed_ap_locations, null) != null || try(device.secondary_managed_ap_locations, null) != null) && !contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE") && contains(local.sites, try(device.site, "NONE")) }
 
   network_device_id = coalesce(
     try(lookup(local.device_name_to_id, each.value.name, null), null),
@@ -373,7 +372,7 @@ resource "catalystcenter_wireless_device_provision" "wireless_controller" {
 }
 
 resource "catalystcenter_assign_managed_ap_locations" "managed_ap_locations" {
-  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && (contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE") || try(device.primary_managed_ap_locations, null) != null || try(device.secondary_managed_ap_locations, null) != null) && contains(local.sites, try(device.site, "NONE")) }
+  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION")) && (contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE") || try(device.primary_managed_ap_locations, null) != null || try(device.secondary_managed_ap_locations, null) != null) && contains(local.sites, try(device.site, "NONE")) }
 
   primary_managed_ap_locations_site_ids   = [for site in try(each.value.primary_managed_ap_locations, []) : try(local.site_id_list[each.value.primary_managed_ap_locations], local.site_id_list[site], coalesce(local.site_id_list_bulk[site], local.data_source_created_sites_list[site]), null)]
   secondary_managed_ap_locations_site_ids = [for site in try(each.value.secondary_managed_ap_locations, []) : try(local.site_id_list[each.value.secondary_managed_ap_locations], local.site_id_list[site], coalesce(local.site_id_list_bulk[site], local.data_source_created_sites_list[site]), null)]
@@ -394,7 +393,7 @@ resource "time_sleep" "wait_for_managed_ap_locations" {
 
 locals {
   provisioned_access_points = [
-    for device in try(local.catalyst_center.inventory.devices, []) : device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && try(device.type, null) == "AccessPoint" && contains(local.sites, try(device.site, "NONE"))
+    for device in try(local.catalyst_center.inventory.devices, []) : device if(strcontains(device.state, "PROVISION")) && try(device.type, null) == "AccessPoint" && contains(local.sites, try(device.site, "NONE"))
   ]
 
   provisioned_access_points_by_site = {

--- a/cc_fabric.tf
+++ b/cc_fabric.tf
@@ -674,7 +674,7 @@ resource "catalystcenter_anycast_gateways" "anycast_gateways_zone" {
 locals {
   border_devices = { for device in try(local.catalyst_center.fabric.border_devices, []) : device.name => device }
 
-  fabric_devices = [for device in try(local.catalyst_center.inventory.devices, []) : device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && try(device.fabric_roles, null) != null && contains(local.sites, try(device.site, "NONE"))]
+  fabric_devices = [for device in try(local.catalyst_center.inventory.devices, []) : device if(strcontains(device.state, "PROVISION")) && try(device.fabric_roles, null) != null && contains(local.sites, try(device.site, "NONE"))]
 
   fabric_devices_by_site = {
     for fabric_site in distinct([for d in try(local.catalyst_center.inventory.devices, []) : try(d.fabric_site, "") if try(d.fabric_zone, "") == ""]) :
@@ -752,7 +752,7 @@ resource "catalystcenter_fabric_devices" "fabric_devices_zone" {
 }
 
 resource "catalystcenter_fabric_device" "border_device" {
-  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && contains(try(device.fabric_roles, []), "BORDER_NODE") && contains(local.sites, try(device.fabric_site, "NONE")) && var.use_bulk_api == false }
+  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION")) && contains(try(device.fabric_roles, []), "BORDER_NODE") && contains(local.sites, try(device.fabric_site, "NONE")) && var.use_bulk_api == false }
 
   network_device_id = coalesce(
     try(lookup(local.device_name_to_id, each.value.name, null), null),
@@ -778,7 +778,7 @@ resource "catalystcenter_fabric_device" "border_device" {
 }
 
 resource "catalystcenter_fabric_device" "wireless_controller" {
-  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE") && (contains(local.sites, try(device.fabric_site, "NONE")) || contains(local.sites, try(device.fabric_zone, "NONE"))) && var.use_bulk_api == false }
+  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION")) && contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE") && (contains(local.sites, try(device.fabric_site, "NONE")) || contains(local.sites, try(device.fabric_zone, "NONE"))) && var.use_bulk_api == false }
 
   network_device_id = coalesce(
     try(lookup(local.device_name_to_id, each.value.name, null), null),
@@ -792,7 +792,7 @@ resource "catalystcenter_fabric_device" "wireless_controller" {
 }
 
 resource "catalystcenter_fabric_device" "edge_device" {
-  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && !contains(try(device.fabric_roles, []), "BORDER_NODE") && try(device.fabric_roles, null) != null && contains(try(device.fabric_roles, []), "EDGE_NODE") && (contains(local.sites, try(device.fabric_site, "NONE")) || contains(local.sites, try(device.fabric_zone, "NONE"))) && var.use_bulk_api == false }
+  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION")) && !contains(try(device.fabric_roles, []), "BORDER_NODE") && try(device.fabric_roles, null) != null && contains(try(device.fabric_roles, []), "EDGE_NODE") && (contains(local.sites, try(device.fabric_site, "NONE")) || contains(local.sites, try(device.fabric_zone, "NONE"))) && var.use_bulk_api == false }
 
   network_device_id = coalesce(
     try(lookup(local.device_name_to_id, each.value.name, null), null),
@@ -813,7 +813,7 @@ resource "catalystcenter_fabric_device" "edge_device" {
 }
 
 resource "catalystcenter_fabric_ewlc" "ewlc_device" {
-  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE") && contains(local.sites, try(device.fabric_site, "NONE")) }
+  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION")) && contains(try(device.fabric_roles, []), "EMBEDDED_WIRELESS_CONTROLLER_NODE") && contains(local.sites, try(device.fabric_site, "NONE")) }
 
   network_device_id = coalesce(
     try(lookup(local.device_name_to_id, each.value.name, null), null),
@@ -843,7 +843,7 @@ resource "catalystcenter_fabric_vlan_to_ssid" "vlan_to_ssid" {
 }
 
 resource "catalystcenter_fabric_l3_handoff_sda_transit" "sda_transit" {
-  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && contains(try(device.fabric_roles, []), "BORDER_NODE") && try(local.border_devices[device.name].sda_transit, null) != null && contains(local.sites, try(device.fabric_site, "NONE")) }
+  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION")) && contains(try(device.fabric_roles, []), "BORDER_NODE") && try(local.border_devices[device.name].sda_transit, null) != null && contains(local.sites, try(device.fabric_site, "NONE")) }
 
   network_device_id = coalesce(
     try(lookup(local.device_name_to_id, each.value.name, null), null),
@@ -888,7 +888,7 @@ locals {
 }
 
 resource "catalystcenter_fabric_l3_handoff_ip_transits" "l3_handoff_ip_transits" {
-  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && contains(try(device.fabric_roles, []), "BORDER_NODE") && length(try(local.l3_handoffs_ip_transit_by_device[device.name], [])) != 0 && contains(local.sites, try(device.fabric_site, "NONE")) }
+  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION")) && contains(try(device.fabric_roles, []), "BORDER_NODE") && length(try(local.l3_handoffs_ip_transit_by_device[device.name], [])) != 0 && contains(local.sites, try(device.fabric_site, "NONE")) }
 
   fabric_id = try(catalystcenter_fabric_zone.fabric_zone[each.value.fabric_zone].id, catalystcenter_fabric_site.fabric_site[each.value.fabric_site].id, null)
   network_device_id = coalesce(
@@ -983,7 +983,7 @@ data "catalystcenter_anycast_gateways" "created_gateways" {
 
 
 resource "catalystcenter_fabric_l2_handoff" "l2_handoff" {
-  for_each = { for handoff in local.l2_handoffs : handoff.key => handoff if(strcontains(local.all_devices[handoff.device_name].state, "PROVISION") || local.all_devices[handoff.device_name].state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(local.all_devices[handoff.device_name].fabric_site, "NONE")) }
+  for_each = { for handoff in local.l2_handoffs : handoff.key => handoff if(strcontains(local.all_devices[handoff.device_name].state, "PROVISION")) && contains(local.sites, try(local.all_devices[handoff.device_name].fabric_site, "NONE")) }
 
   network_device_id = lookup(local.device_ip_to_id, each.value.device_ip, null)
   fabric_id         = try(catalystcenter_fabric_site.fabric_site[local.all_devices[each.value.device_name].fabric_site].id, null)
@@ -1023,7 +1023,7 @@ locals {
 }
 
 resource "catalystcenter_fabric_l2_handoff" "l2_handoff_no_anycast" {
-  for_each = { for handoff in local.l2_handoffs_no_anycast : handoff.key => handoff if(strcontains(local.all_devices[handoff.device_name].state, "PROVISION") || local.all_devices[handoff.device_name].state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(local.all_devices[handoff.device_name].fabric_site, "NONE")) }
+  for_each = { for handoff in local.l2_handoffs_no_anycast : handoff.key => handoff if(strcontains(local.all_devices[handoff.device_name].state, "PROVISION")) && contains(local.sites, try(local.all_devices[handoff.device_name].fabric_site, "NONE")) }
 
   network_device_id = lookup(local.device_ip_to_id, each.value.device_ip, null)
   fabric_id         = try(catalystcenter_fabric_site.fabric_site[local.all_devices[each.value.device_name].fabric_site].id, null)
@@ -1087,7 +1087,7 @@ locals {
 }
 
 resource "catalystcenter_fabric_port_assignments" "port_assignments" {
-  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && try(contains(device.fabric_roles, "EDGE_NODE"), false) && try(device.port_assignments, null) != null && (contains(local.sites, try(device.fabric_site, "NONE")) || contains(local.sites, try(device.fabric_zone, "NONE"))) }
+  for_each = { for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION")) && try(contains(device.fabric_roles, "EDGE_NODE"), false) && try(device.port_assignments, null) != null && (contains(local.sites, try(device.fabric_site, "NONE")) || contains(local.sites, try(device.fabric_zone, "NONE"))) }
 
   fabric_id = try(catalystcenter_fabric_zone.fabric_zone[each.value.fabric_zone].id, catalystcenter_fabric_site.fabric_site[each.value.fabric_site].id, null)
   network_device_id = coalesce(

--- a/cc_rma.tf
+++ b/cc_rma.tf
@@ -1,35 +1,22 @@
-data "catalystcenter_device_replacement" "rma_device" {
-  for_each = {
-    for device in try(local.catalyst_center.inventory.devices, []) :
-    device.name => device
-    if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT")
-    && try(device.serial_number, null) != null
-    && contains(local.sites, try(device.site, "NONE"))
-    && (
-      lookup(local.device_name_to_id, device.name, null) != null ||
-      lookup(local.device_name_to_id, try(device.fqdn_name, ""), null) != null ||
-      lookup(local.device_ip_to_id, try(device.device_ip, ""), null) != null
-    )
-  }
-
-  faulty_device_id = coalesce(
-    try(lookup(local.device_name_to_id, each.value.name, null), null),
-    try(lookup(local.device_name_to_id, each.value.fqdn_name, null), null),
-    try(lookup(local.device_ip_to_id, each.value.device_ip, null), null)
-  )
-}
+# RMA (Return Material Authorization) device replacement — 3-step workflow.
+#
+# Driven by the optional `rma` block on an inventory device; the device `state`
+# stays `PROVISION` throughout, so none of the device's existing resources
+# (provisioning, fabric roles, templates, port assignments) are torn down while
+# a replacement is in flight. Every `for_each` key derives from static
+# data-model values (device name + `rma.action`), so plan/`terraform import`
+# never hit the "Invalid for_each argument" error that the previous
+# state-driven design produced (netascode/nac-catalystcenter#530).
+#
+#   Step 1 — mark:    rma.action = MARK_FOR_REPLACEMENT
+#   Step 2 — replace: rma.action = REPLACE, rma.replacement_serial_number = <new SN>
+#   Step 3 — cleanup: remove the rma block (device is un-marked, back to normal)
 
 resource "catalystcenter_device_replacement" "mark" {
   for_each = {
     for device in try(local.catalyst_center.inventory.devices, []) :
     device.name => device
-    if(
-      device.state == "MARK_FOR_REPLACEMENT"
-      || (
-        strcontains(device.state, "PROVISION")
-        && try(data.catalystcenter_device_replacement.rma_device[device.name].faulty_device_serial_number, null) != null
-      )
-    )
+    if contains(["MARK_FOR_REPLACEMENT", "REPLACE"], try(device.rma.action, "NONE"))
     && contains(local.sites, try(device.site, "NONE"))
     && (
       lookup(local.device_name_to_id, device.name, null) != null ||
@@ -52,15 +39,15 @@ resource "catalystcenter_device_replacement_workflow" "rma" {
   for_each = {
     for device in try(local.catalyst_center.inventory.devices, []) :
     device.name => device
-    if strcontains(device.state, "PROVISION")
+    if try(device.rma.action, "NONE") == "REPLACE"
+    && try(device.rma.replacement_serial_number, null) != null
     && try(device.serial_number, null) != null
+    && try(device.rma.replacement_serial_number, "") != try(device.serial_number, "")
     && contains(local.sites, try(device.site, "NONE"))
-    && try(data.catalystcenter_device_replacement.rma_device[device.name].faulty_device_serial_number, null) != null
-    && try(device.serial_number, "") != try(data.catalystcenter_device_replacement.rma_device[device.name].faulty_device_serial_number, "")
   }
 
-  faulty_device_serial_number      = data.catalystcenter_device_replacement.rma_device[each.key].faulty_device_serial_number
-  replacement_device_serial_number = each.value.serial_number
+  faulty_device_serial_number      = each.value.serial_number
+  replacement_device_serial_number = each.value.rma.replacement_serial_number
 
   depends_on = [data.catalystcenter_network_devices.all_devices, catalystcenter_device_replacement.mark]
 }

--- a/cc_templates.tf
+++ b/cc_templates.tf
@@ -118,7 +118,7 @@ locals {
         "device_ip"   = try(device.device_ip, null)
         "fqdn_name"   = device.fqdn_name
       }
-    ] if try(device.tags, null) != null && (strcontains(device.state, "PROVISION") || device.state == "ASSIGN" || device.state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(device.site, "NONE"))
+    ] if try(device.tags, null) != null && (strcontains(device.state, "PROVISION") || device.state == "ASSIGN") && contains(local.sites, try(device.site, "NONE"))
   ])
 
   devices_to_tag = [
@@ -528,7 +528,7 @@ resource "catalystcenter_deploy_template" "regular_template_deploy" {
     for tmpl, devices in local.templates_by_device : tmpl => devices
     if try(local.template_lookup_extended[tmpl].composite, false) == false &&
     try(local.template_lookup_extended[tmpl].template_type, null) == "dayn" &&
-    length([for d in devices : d if(strcontains(d.state, "PROVISION") || d.state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(d.site, "NONE"))]) > 0
+    length([for d in devices : d if(strcontains(d.state, "PROVISION")) && contains(local.sites, try(d.site, "NONE"))]) > 0
   }
 
   template_id         = try(catalystcenter_template.regular_template[each.key].id, data.catalystcenter_template.template[each.key].id, data.catalystcenter_template.template[local.resource_key_to_template_key[each.key]].id, data.catalystcenter_template.unmanaged[each.key].id)
@@ -561,7 +561,7 @@ resource "catalystcenter_deploy_template" "regular_template_deploy" {
           )
         }
       ]
-    } if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(device.site, "NONE"))
+    } if(strcontains(device.state, "PROVISION")) && contains(local.sites, try(device.site, "NONE"))
   ]
 
   depends_on = [catalystcenter_device_role.role, catalystcenter_provision_devices.provision_devices, catalystcenter_provision_device.provision_device, time_sleep.provision_device_wait, catalystcenter_template_version.regular_commit_version, data.catalystcenter_template_versions.template_versions]
@@ -572,7 +572,7 @@ resource "catalystcenter_deploy_template" "composite_template_deploy" {
     for tmpl, devices in local.templates_by_device : tmpl => devices
     if try(local.template_lookup[tmpl].composite, false) == true &&
     local.template_lookup[tmpl].template_type == "dayn" &&
-    length([for d in devices : d if(strcontains(d.state, "PROVISION") || d.state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(d.site, "NONE"))]) > 0
+    length([for d in devices : d if(strcontains(d.state, "PROVISION")) && contains(local.sites, try(d.site, "NONE"))]) > 0
   }
 
   redeploy            = try(local.template_lookup[each.key].redeploy_template, "NEVER")
@@ -612,7 +612,7 @@ resource "catalystcenter_deploy_template" "composite_template_deploy" {
             }
           ]
         }
-      ] if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(device.site, "NONE"))
+      ] if(strcontains(device.state, "PROVISION")) && contains(local.sites, try(device.site, "NONE"))
     ])
     }
   ]
@@ -637,7 +637,7 @@ resource "catalystcenter_deploy_template" "composite_template_deploy" {
           )
         }
       ]
-    } if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(device.site, "NONE"))
+    } if(strcontains(device.state, "PROVISION")) && contains(local.sites, try(device.site, "NONE"))
   ]
 
   depends_on = [catalystcenter_device_role.role, catalystcenter_provision_devices.provision_devices, catalystcenter_provision_device.provision_device, time_sleep.provision_device_wait, catalystcenter_template_version.composite_commit_version, data.catalystcenter_template_versions.template_versions]
@@ -655,7 +655,7 @@ resource "catalystcenter_deploy_template" "unmanaged_composite_template_deploy" 
   for_each = {
     for tmpl, devices in local.templates_by_device : tmpl => devices
     if contains(local.unmanaged_composite_keys, tmpl) &&
-    length([for d in devices : d if(strcontains(d.state, "PROVISION") || d.state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(d.site, "NONE"))]) > 0
+    length([for d in devices : d if(strcontains(d.state, "PROVISION")) && contains(local.sites, try(d.site, "NONE"))]) > 0
   }
 
   redeploy            = try(local.template_lookup_extended[each.key].redeploy_template, "NEVER")
@@ -695,7 +695,7 @@ resource "catalystcenter_deploy_template" "unmanaged_composite_template_deploy" 
             }
           ]
         }
-      ] if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(device.site, "NONE"))
+      ] if(strcontains(device.state, "PROVISION")) && contains(local.sites, try(device.site, "NONE"))
     ])
     }
   ]
@@ -720,7 +720,7 @@ resource "catalystcenter_deploy_template" "unmanaged_composite_template_deploy" 
           )
         }
       ]
-    } if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && contains(local.sites, try(device.site, "NONE"))
+    } if(strcontains(device.state, "PROVISION")) && contains(local.sites, try(device.site, "NONE"))
   ]
 
   depends_on = [catalystcenter_device_role.role, catalystcenter_provision_devices.provision_devices, catalystcenter_provision_device.provision_device, time_sleep.provision_device_wait, data.catalystcenter_template.unmanaged, data.catalystcenter_template_versions.unmanaged, data.catalystcenter_template_versions.unmanaged_member]

--- a/cc_wireless.tf
+++ b/cc_wireless.tf
@@ -31,7 +31,7 @@ locals {
   }
 
   wireless_controllers = length({
-    for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION") || device.state == "MARK_FOR_REPLACEMENT") && contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE")
+    for device in try(local.catalyst_center.inventory.devices, []) : device.name => device if(strcontains(device.state, "PROVISION")) && contains(try(device.fabric_roles, []), "WIRELESS_CONTROLLER_NODE")
   }) > 0
 
   short_hostname_to_fqdn = try({


### PR DESCRIPTION
Replace the state-driven 2-step RMA design with an explicit
inventory.devices[].rma block (MARK_FOR_REPLACEMENT -> REPLACE ->
remove block). The device state now stays PROVISION for the whole
replacement, so every catalystcenter_device_replacement /
catalystcenter_device_replacement_workflow for_each key derives only
from static data-model values. This removes the apply-time-unknown
catalystcenter_device_replacement data source that made for_each keys
undeterminable and broke terraform import/plan on setups with
provisioned devices.

Also drop the MARK_FOR_REPLACEMENT state value from all device state
filters across cc_device_provision.tf, cc_fabric.tf, cc_templates.tf
and cc_wireless.tf, and rewrite cc_rma.tf accordingly.

Fixes netascode/nac-catalystcenter#530
Refs netascode/nac-catalystcenter#328